### PR TITLE
Open external links in new tab

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -23,6 +23,9 @@
                 addCheckbox(this);
             }
         });
+        
+        // Open external links in new tab
+        $("a[href^='http']").attr('target','_blank');
 
         populateProfiles();
 


### PR DESCRIPTION
Currently links to the DS3 wiki open in the same page, which can be inconvenient.
