### PR TITLE
Button to show/hide completed items

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
     </div>
 
     <div class="tab-content">
+	  <button class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
       <!-- PLAYTHROUGH START -->
       <div class="tab-pane active" id="tabPlaythrough">
         <h2>Playthrough Checklist <span id="playthrough_overall_total"></span></h2>

--- a/js/main.js
+++ b/js/main.js
@@ -36,6 +36,11 @@
             //_gaq.push(['_trackEvent', 'Checkbox', (isChecked ? 'Check' : 'Uncheck'), id]);
             if (isChecked === true) {
               $('[data-id="'+id+'"] label').addClass('stroked');
+			  
+			  if ($("#toggleHideCompleted").data("hidden") === true) { 
+				$('[data-id="'+id+'"] label').hide();
+			  }
+			  
             } else {
               $('[data-id="'+id+'"] label').removeClass('stroked');
             }
@@ -154,6 +159,20 @@
           fr.readAsText(fileInput.files[0]);
           fr.onload = dataLoadCallback;
         });
+		
+		$("#toggleHideCompleted").click(function() {
+			var hidden = $(this).data("hidden");
+			
+			if (hidden === true) {
+				$(this).text("Hide completed");
+			} else { 
+				$(this).text("Show completed");
+			}
+			
+			$(this).data("hidden", !hidden);
+			
+			toggleCompletedCheckboxes(!hidden);
+		});
 
         calculateTotals();
 
@@ -248,5 +267,15 @@
             return profile;
         }
     }
+	
+	function toggleCompletedCheckboxes(hide) {
+		$("li .checkbox .stroked").parentsUntil("ul").each(function(index) {
+			if (hide === true) { 
+				$(this).hide(); 
+			} else { 
+				$(this).show();
+			};
+		});
+	}
 
 })( jQuery );

--- a/js/main.js
+++ b/js/main.js
@@ -36,11 +36,10 @@
             //_gaq.push(['_trackEvent', 'Checkbox', (isChecked ? 'Check' : 'Uncheck'), id]);
             if (isChecked === true) {
               $('[data-id="'+id+'"] label').addClass('stroked');
-			  
-			  if ($("#toggleHideCompleted").data("hidden") === true) { 
-				$('[data-id="'+id+'"] label').hide();
-			  }
-			  
+
+              if ($("#toggleHideCompleted").data("hidden") === true) { 
+                $('[data-id="'+id+'"] label').hide();
+              }           
             } else {
               $('[data-id="'+id+'"] label').removeClass('stroked');
             }
@@ -159,20 +158,20 @@
           fr.readAsText(fileInput.files[0]);
           fr.onload = dataLoadCallback;
         });
-		
-		$("#toggleHideCompleted").click(function() {
-			var hidden = $(this).data("hidden");
-			
-			if (hidden === true) {
-				$(this).text("Hide completed");
-			} else { 
-				$(this).text("Show completed");
-			}
-			
-			$(this).data("hidden", !hidden);
-			
-			toggleCompletedCheckboxes(!hidden);
-		});
+        
+        $("#toggleHideCompleted").click(function() {
+            var hidden = $(this).data("hidden");
+            
+            if (hidden === true) {
+                $(this).text("Hide completed");
+            } else { 
+                $(this).text("Show completed");
+            }
+            
+            $(this).data("hidden", !hidden);
+            
+            toggleCompletedCheckboxes(!hidden);
+        });
 
         calculateTotals();
 
@@ -267,15 +266,15 @@
             return profile;
         }
     }
-	
-	function toggleCompletedCheckboxes(hide) {
-		$("li .checkbox .stroked").parentsUntil("ul").each(function(index) {
-			if (hide === true) { 
-				$(this).hide(); 
-			} else { 
-				$(this).show();
-			};
-		});
-	}
+    
+    function toggleCompletedCheckboxes(hide) {
+        $("li .checkbox .stroked").parentsUntil("ul").each(function() {
+            if (hide === true) { 
+                $(this).hide(); 
+            } else { 
+                $(this).show();
+            };
+        });
+    }
 
 })( jQuery );


### PR DESCRIPTION
Saw [this suggestion](https://github.com/ZKjellberg/dark-souls-3-cheat-sheet/issues/31) which suggested to add the option to hide completed item.

I figured it might be a helpful addition so I went ahead and added a button that allows you to toggle hiding and showing completed items.

Currently it doesn't put the value of whether to show/hide completed items in the LocalStorage so you'll have to toggle it manually every time you want to hide completed items again.
