### PR TITLE
Adding missed equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,7 +1033,7 @@
             <li data-id="armors_1_27"><a href="http://darksouls3.wiki.fextralife.com/Xanthous+Crown">Xanthous Crown</a></li>
             <li data-id="armors_1_28"><a href="http://darksouls3.wiki.fextralife.com/Fire+Witch+Helm">Fire Witch Helm</a></li>
             <li data-id="armors_1_29"><a href="http://darksouls3.wiki.fextralife.com/Black+Iron+Helm">Black Iron Helm</a></li>
-            <li data-id="armors_1_30"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Helm">Excecutioner Helm</a></li>
+            <li data-id="armors_1_30"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Helm">Executioner Helm</a></li>
             <li data-id="armors_1_31"><a href="http://darksouls3.wiki.fextralife.com/Pontiff+Knight+Crown">Pontiff Knight Crown</a></li>
             <li data-id="armors_1_32"><a href="http://darksouls3.wiki.fextralife.com/Court+Sorcerer+Hood">Court Sorcerer Hood</a></li>
             <li data-id="armors_1_33"><a href="http://darksouls3.wiki.fextralife.com/Brass+Helm">Brass Helm</a></li>
@@ -1081,6 +1081,7 @@
             <li data-id="armors_1_75"><a href="http://darksouls3.wiki.fextralife.com/Pharis's+Hat">Pharis' Hat</a></li>
             <li data-id="armors_1_76"><a href="http://darksouls3.wiki.fextralife.com/Sneering+Mask">Sneering Mask</a></li>
             <li data-id="armors_1_77"><a href="http://darksouls3.wiki.fextralife.com/Ragged%20Mask">Ragged Mask</a></li>
+            <li data-id="armors_1_78"><a href="#">Sage's Big Hat</a></li>
           </ul>
           <h3 id="Chests"><a href="#Chests_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/Armor">Chests</a><span id="armors_totals_2"></span></h3>
           <ul id="Chests_col" class="collapse in">
@@ -1117,7 +1118,7 @@
             <li data-id="armors_2_31"><a href="http://darksouls3.wiki.fextralife.com/Drang+Armor">Drang Armor</a></li>
             <li data-id="armors_2_32"><a href="http://darksouls3.wiki.fextralife.com/Eastern+Armor">Eastern Armor</a></li>
             <li data-id="armors_2_33"><a href="http://darksouls3.wiki.fextralife.com/Black+Iron+Armor">Black Iron Armor</a></li>
-            <li data-id="armors_2_34"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Armor">Excecutioner Armor</a></li>
+            <li data-id="armors_2_34"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Armor">Executioner Armor</a></li>
             <li data-id="armors_2_35"><a href="http://darksouls3.wiki.fextralife.com/Xanthous+Overcoat">Xanthous Overcoat</a></li>
             <li data-id="armors_2_36"><a href="http://darksouls3.wiki.fextralife.com/Court+Sorcerer+Robe">Court Sorcerer Robe</a></li>
             <li data-id="armors_2_37"><a href="http://darksouls3.wiki.fextralife.com/Brass+Armor">Brass Armor</a></li>
@@ -1187,10 +1188,11 @@
             <li data-id="armors_3_20"><a href="http://darksouls3.wiki.fextralife.com/Black+Leather+Gloves">Black Leather Gloves</a></li>
             <li data-id="armors_3_21"><a href="http://darksouls3.wiki.fextralife.com/Fire+Keeper+Gloves">Fire Keeper Gloves</a></li>
             <li data-id="armors_3_22"><a href="http://darksouls3.wiki.fextralife.com/Sorcerer+Gloves">Sorcerer Gloves</a></li>
+            <li data-id="armors_3_71"><a href="http://darksouls3.wiki.fextralife.com/Sellsword+Gauntlet">Sellsword Gauntlets</a></li>
             <li data-id="armors_3_23"><a href="http://darksouls3.wiki.fextralife.com/Drang+Gauntlets">Drang Gauntlets</a></li>
             <li data-id="armors_3_24"><a href="http://darksouls3.wiki.fextralife.com/Eastern+Gauntlets">Eastern Gauntlets</a></li>
             <li data-id="armors_3_25"><a href="http://darksouls3.wiki.fextralife.com/Black+Iron+Gauntlets">Black Iron Gauntlets</a></li>
-            <li data-id="armors_3_26"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Gauntlets">Excecutioner Gauntlets</a></li>
+            <li data-id="armors_3_26"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Gauntlets">Executioner Gauntlets</a></li>
             <li data-id="armors_3_27"><a href="http://darksouls3.wiki.fextralife.com/Xanthous+Gloves">Xanthous Gloves</a></li>
             <li data-id="armors_3_28"><a href="http://darksouls3.wiki.fextralife.com/Court+Sorcerer+Gloves">Court Sorcerer Gloves</a></li>
             <li data-id="armors_3_29"><a href="http://darksouls3.wiki.fextralife.com/Brass+Gauntlets">Brass Gauntlets</a></li>
@@ -1199,6 +1201,7 @@
             <li data-id="armors_3_32"><a href="http://darksouls3.wiki.fextralife.com/Shadow+Gauntlets">Shadow Gauntlets</a></li>
             <li data-id="armors_3_33"><a href="http://darksouls3.wiki.fextralife.com/Winged+Knight+Gauntlets">Winged Knight Gauntlets</a></li>
             <li data-id="armors_3_34"><a href="http://darksouls3.wiki.fextralife.com/Cathedral+Knight+Gauntlets">Cathedral Knight Gauntlets</a></li>
+            <li data-id="armors_3_70"><a href="#">Grave Warden Wrap</a></li>
             <li data-id="armors_3_35"><a href="http://darksouls3.wiki.fextralife.com/Gundyr's+Gauntlets">Gundyr's Gauntlets</a></li>
             <li data-id="armors_3_36"><a href="http://darksouls3.wiki.fextralife.com/Elite+Knight+Gauntlets">Elite Knight Gauntlets</a></li>
             <li data-id="armors_3_37"><a href="http://darksouls3.wiki.fextralife.com/Lothric+Knight+Gauntlets">Lothric Knight Gauntlets</a></li>
@@ -1218,6 +1221,7 @@
             <li data-id="armors_3_51"><a href="http://darksouls3.wiki.fextralife.com/Leonhard's+Gauntlets">Leonhard's Gauntlets</a></li>
             <li data-id="armors_3_52"><a href="http://darksouls3.wiki.fextralife.com/Lorian's+Gauntlets">Lorian's Gauntlets</a></li>
             <li data-id="armors_3_53"><a href="http://darksouls3.wiki.fextralife.com/Sunless+Gauntlets">Sunless Gauntlets</a></li>
+            <li data-id="armors_3_69"><a href="http://darksouls3.wiki.fextralife.com/Jailer+Gloves">Jailer Gloves</a></li>
             <li data-id="armors_3_54"><a href="http://darksouls3.wiki.fextralife.com/Sunset+Gauntlets">Sunset Gauntlets</a></li>
             <li data-id="armors_3_55"><a href="http://darksouls3.wiki.fextralife.com/Pontiff+Knight+Gauntlets">Pontiff Knight Gauntlets</a></li>
             <li data-id="armors_3_56"><a href="http://darksouls3.wiki.fextralife.com/Silver+Knight+Gauntlets">Silver Knight Gauntlets</a></li>
@@ -1228,6 +1232,7 @@
             <li data-id="armors_3_61"><a href="http://darksouls3.wiki.fextralife.com/Leather+Gloves">Leather Gloves</a></li>
             <li data-id="armors_3_62"><a href="http://darksouls3.wiki.fextralife.com/Conjurator+Manchettes">Conjurator Manchettes</a></li>
             <li data-id="armors_3_63"><a href="http://darksouls3.wiki.fextralife.com/Mirrah+Chain+Gloves">Mirrah Chain Gloves</a></li>
+            <li data-id="armors_3_68"><a href="http://darksouls3.wiki.fextralife.com/Antiquated+Gloves">Antiquated Gloves</a></li>
             <li data-id="armors_3_64"><a href="http://darksouls3.wiki.fextralife.com/Gauntlets+of+Thorns">Gauntlets of Thorns</a></li>
             <li data-id="armors_3_65"><a href="http://darksouls3.wiki.fextralife.com/Old+Sorcerer+Gauntlets">Old Sorcerer Gauntlets</a></li>
             <li data-id="armors_3_66"><a href="http://darksouls3.wiki.fextralife.com/Alva+Gauntlets">Alva Gauntlets</a></li>
@@ -1262,7 +1267,7 @@
             <li data-id="armors_4_25"><a href="http://darksouls3.wiki.fextralife.com/Eastern+Leggings">Eastern Leggings</a></li>
             <li data-id="armors_4_26"><a href="http://darksouls3.wiki.fextralife.com/Black+Knight+Leggings">Black Knight Leggings</a></li>
             <li data-id="armors_4_27"><a href="http://darksouls3.wiki.fextralife.com/Pontiff+Knight+Leggings">Pontiff Knight Leggings</a></li>
-            <li data-id="armors_4_28"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Leggings">Excecutioner Leggings</a></li>
+            <li data-id="armors_4_28"><a href="http://darksouls3.wiki.fextralife.com/Executioner+Leggings">Executioner Leggings</a></li>
             <li data-id="armors_4_29"><a href="http://darksouls3.wiki.fextralife.com/Black+Iron+Leggings">Black Iron Leggings</a></li>
             <li data-id="armors_4_30"><a href="http://darksouls3.wiki.fextralife.com/Xanthous+Trousers">Xanthous Trousers</a></li>
             <li data-id="armors_4_31"><a href="http://darksouls3.wiki.fextralife.com/Court+Sorcerer+Trousers">Court Sorcerer Trousers</a></li>

--- a/index.html
+++ b/index.html
@@ -1095,6 +1095,7 @@
             <li data-id="armors_2_8"><a href="http://darksouls3.wiki.fextralife.com/Northern%20Armor">Northern Armor</a></li>
             <li data-id="armors_2_9"><a href="http://darksouls3.wiki.fextralife.com/Pyromancer+Garb">Pyromancer Garb</a></li>
             <li data-id="armors_2_10"><a href="http://darksouls3.wiki.fextralife.com/Lothric%20Knight+Armor">Lothric Knight Armor</a></li>
+            <li data-id="armors_2_79"><a href="http://darksouls3.wiki.fextralife.com/Evangelist%20Robe">Evangelist Robe</a></li>
             <li data-id="armors_2_11"><a href="http://darksouls3.wiki.fextralife.com/Master's%20Attire">Master's Attire</a></li>
             <li data-id="armors_2_12"><a href="http://darksouls3.wiki.fextralife.com/Assassin%20Armor">Assassin Armor</a></li>
             <li data-id="armors_2_13"><a href="http://darksouls3.wiki.fextralife.com/Worker%20Garb">Worker Garb</a></li>

--- a/index.html
+++ b/index.html
@@ -981,6 +981,7 @@
             <li data-id="weapons_2_55"><a href="http://darksouls3.wiki.fextralife.com/Havel's+Greatshield">Havel's Greatshield</a></li>
             <li data-id="weapons_2_56"><a href="http://darksouls3.wiki.fextralife.com/Ancient+Dragon+Greatshield">Ancient Dragon Greatshield</a></li>
             <li data-id="weapons_2_57"><a href="http://darksouls3.wiki.fextralife.com/Wolf+Knight's+Greatshield">Wolf Knight's Greatshield</a></li>
+            <li data-id="weapons_2_58"><a href="http://darksouls3.wiki.fextralife.com/Cathedral+Knight+Greatshield">Cathedral Knight Greatshield</a></li>
           </ul>
       </div>
     </div>
@@ -1095,6 +1096,7 @@
             <li data-id="armors_2_8"><a href="http://darksouls3.wiki.fextralife.com/Northern%20Armor">Northern Armor</a></li>
             <li data-id="armors_2_9"><a href="http://darksouls3.wiki.fextralife.com/Pyromancer+Garb">Pyromancer Garb</a></li>
             <li data-id="armors_2_10"><a href="http://darksouls3.wiki.fextralife.com/Lothric%20Knight+Armor">Lothric Knight Armor</a></li>
+            <li data-id="armors_2_79"><a href="http://darksouls3.wiki.fextralife.com/Evangelist%20Robe">Evangelist Robe</a></li>
             <li data-id="armors_2_11"><a href="http://darksouls3.wiki.fextralife.com/Master's%20Attire">Master's Attire</a></li>
             <li data-id="armors_2_12"><a href="http://darksouls3.wiki.fextralife.com/Assassin%20Armor">Assassin Armor</a></li>
             <li data-id="armors_2_13"><a href="http://darksouls3.wiki.fextralife.com/Worker%20Garb">Worker Garb</a></li>
@@ -1287,8 +1289,10 @@
             <li data-id="armors_4_45"><a href="http://darksouls3.wiki.fextralife.com/Herald+Trousers">Herald Trousers</a></li>
             <li data-id="armors_4_46"><a href="http://darksouls3.wiki.fextralife.com/Dragonscale+Waistcloth">Dragonscale Waistcloth</a></li>
             <li data-id="armors_4_47"><a href="http://darksouls3.wiki.fextralife.com/Sorcerer+Trousers">Sorcerer Trousers</a></li>
+            <li data-id="armors_4_75"><a href="http://darksouls3.wiki.fextralife.com/Sellsword+Trousers">Sellsword Trousers</a></li>
             <li data-id="armors_4_48"><a href="http://darksouls3.wiki.fextralife.com/Firelink+Leggings">Firelink Leggings</a></li>
             <li data-id="armors_4_49"><a href="http://darksouls3.wiki.fextralife.com/Dragonslayer+Leggings">Dragonslayer Leggings</a></li>
+            <li data-id="armors_4_74"><a href="#">Leggings of Favor</a></li>
             <li data-id="armors_4_50"><a href="http://darksouls3.wiki.fextralife.com/Black+Leggings">Black Leggings</a></li>
             <li data-id="armors_4_51"><a href="http://darksouls3.wiki.fextralife.com/Karla's+Trousers">Karla's Trousers</a></li>
             <li data-id="armors_4_52"><a href="http://darksouls3.wiki.fextralife.com/Cornyx's+Skirt">Cornyx's Skirt</a></li>
@@ -1308,6 +1312,7 @@
             <li data-id="armors_4_66"><a href="http://darksouls3.wiki.fextralife.com/Leather+Boots">Leather Boots</a></li>
             <li data-id="armors_4_67"><a href="http://darksouls3.wiki.fextralife.com/Conjurator+Boots">Conjurator Boots</a></li>
             <li data-id="armors_4_68"><a href="http://darksouls3.wiki.fextralife.com/Leggings+of+Thorns">Leggings of Thorns</a></li>
+            <li data-id="armors_4_73"><a href="http://darksouls3.wiki.fextralife.com/Antiquated+Skirt">Antiquated Skirt</a></li>
             <li data-id="armors_4_69"><a href="http://darksouls3.wiki.fextralife.com/Old+Sorcerer+Boots">Old Sorcerer Boots</a></li>
             <li data-id="armors_4_70"><a href="http://darksouls3.wiki.fextralife.com/Alva+Leggings">Alva Leggings</a></li>
             <li data-id="armors_4_71"><a href="http://darksouls3.wiki.fextralife.com/Pale+Shade+Trousers">Pale Shade Trousers</a></li>


### PR DESCRIPTION
Thanks to everyone who pointed these out. Wiki pages hadn't been created for most of them at the time I made the list, so I missed them.
Copying from Issue #41 The following missed items should be covered by this PR:

**Gloves:**
Executioner(spelling fix)
Antiquated Gloves
Jailer Gloves
Grave Warden Wrap
Sellsword Gauntlets
**Helms:**
Executioner(spelling fix)
Sage's Big Hat
**Chests:**
Executioner(spelling fix)
Evangelist Robe
**Legs:**
Executioner(spelling fix)
Sellsword Trousers
Leggings of Favor
Antiquated Skirt
**Weapons/Shields:**
Cathedral Knight Greatshield

**NOTE**: The wiki pages for some of these pieces of gear have not yet been created. These will need to be updated.
