### PR TITLE
Save/restore page state and some cleanup

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -92,3 +92,8 @@ h3 {
 .btn-collapse.collapsed:after {
   content:"\e081";
 }
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 20px;
+}

--- a/index.html
+++ b/index.html
@@ -1508,52 +1508,19 @@
       </div><!-- /.modal -->
     </div> <!-- tab-content -->
   </div> <!-- container -->
+
+  <div class="hiddenfile">
+    <input name="upload" type="file" id="fileInput"/>
+  </div>
+
+  <a href="#" class="back-to-top">Back to Top</a>
+  
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/andris9/jStorage/v0.4.12/jstorage.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jets/0.8.0/jets.min.js"></script>
   <script src="js/jquery.highlight.js"></script>
-  <script type="text/javascript">var profilesKey = 'darksouls3_profiles';</script>
   <script src="js/main.js"></script>
-  <script>
-    var jets = new Jets({
-      searchTag: '#playthrough_search',
-      contentTag: '#playthrough_list ul'
-    });
-
-    var jets = new Jets({
-      searchTag: '#item_search',
-      contentTag: '#item_list ul'
-    });
-
-    var jets = new Jets({
-      searchTag: '#weapons_search',
-      contentTag: '#weapons_list ul'
-    });
-
-    var jets = new Jets({
-      searchTag: '#armors_search',
-      contentTag: '#armors_list ul'
-    });
-  </script>
-  <script>
-    $('#playthrough_search').keyup(function() {
-      $('#playthrough_list').unhighlight();
-      $('#playthrough_list').highlight($(this).val());
-    });
-    $('#item_search').keyup(function() {
-      $('#item_list').unhighlight();
-      $('#item_list').highlight($(this).val());
-    });
-    $('#weapons_search').keyup(function() {
-      $('#weapons_list').unhighlight();
-      $('#weapons_list').highlight($(this).val());
-    });
-    $('#armors_search').keyup(function() {
-      $('#armors_list').unhighlight();
-      $('#armors_list').highlight($(this).val());
-    });
-  </script>
   <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -1562,30 +1529,5 @@
   ga('create', 'UA-66576837-1', 'auto');
   ga('send', 'pageview');
   </script>
-
-  <div class="hiddenfile">
-    <input name="upload" type="file" id="fileInput"/>
-  </div>
-
-  <a href="#" class="back-to-top">Back to Top</a>
-  <script>
-  jQuery(document).ready(function() {
-    var offset = 220;
-    var duration = 500;
-    jQuery(window).scroll(function() {
-        if (jQuery(this).scrollTop() > offset) {
-            jQuery('.back-to-top').fadeIn(duration);
-        } else {
-            jQuery('.back-to-top').fadeOut(duration);
-        }
-    });
-
-    jQuery('.back-to-top').click(function(event) {
-        event.preventDefault();
-        jQuery('html, body').animate({scrollTop: 0}, duration);
-        return false;
-    })
-	});
-	</script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
   <![endif]-->
 </head>
 <body>
-
   <nav class="navbar navbar-default">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
@@ -24,7 +23,6 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="#">Dark Souls 3 Cheat Sheet</a>
       </div>
 
       <!-- Collect the nav links, forms, and other content for toggling -->
@@ -51,6 +49,11 @@
   </nav>
 
   <div class="container">
+    <div class="row">
+      <div class="col-md-12 text-center">
+        <h1>Dark&nbsp;Souls&nbsp;3 Cheat&nbsp;Sheet</h1>
+      </div>
+    </div>
 
     <div id="intro">
       <p>

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,5 @@
+var profilesKey = 'darksouls3_profiles';
+
 (function($) {
     'use strict';
 
@@ -13,13 +15,7 @@
 
     jQuery(document).ready(function($) {
 
-        // TODO Find a better way to do this in one pass
-        $('ul li li').each(function(index) {
-            if ($(this).attr('data-id')) {
-                addCheckbox(this);
-            }
-        });
-        $('ul li').each(function(index) {
+        $('ul li li[data-id], ul li[data-id]').each(function(index) {
             if ($(this).attr('data-id')) {
                 addCheckbox(this);
             }
@@ -136,8 +132,8 @@
           var filename = "profiles.json";
           var text = JSON.stringify(profiles);
           var element = document.createElement('a');
-          element.setAttribute('href', 'data:text/plain;charset=utf-8,'
-            + encodeURIComponent(text));
+          element.setAttribute('href', 'data:text/plain;charset=utf-8,' +
+            encodeURIComponent(text));
           element.setAttribute('download', filename);
           element.style.display = 'none';
           document.body.appendChild(element);
@@ -273,8 +269,68 @@
                 $(this).hide();
             } else {
                 $(this).show();
-            };
+            }
         });
     }
 
+    /*
+     * ----------------------------------
+     * Search and highlight functionality
+     * ----------------------------------
+     */
+    $(function() {
+        var jets = [new Jets({
+            searchTag: '#playthrough_search',
+            contentTag: '#playthrough_list ul'
+        }), new Jets({
+            searchTag: '#item_search',
+            contentTag: '#item_list ul'
+        }), new Jets({
+            searchTag: '#weapons_search',
+            contentTag: '#weapons_list ul'
+        }), new Jets({
+            searchTag: '#armors_search',
+            contentTag: '#armors_list ul'
+        })];
+
+        $('#playthrough_search').keyup(function() {
+            $('#playthrough_list').unhighlight();
+            $('#playthrough_list').highlight($(this).val());
+        });
+        $('#item_search').keyup(function() {
+            $('#item_list').unhighlight();
+            $('#item_list').highlight($(this).val());
+        });
+        $('#weapons_search').keyup(function() {
+            $('#weapons_list').unhighlight();
+            $('#weapons_list').highlight($(this).val());
+        });
+        $('#armors_search').keyup(function() {
+            $('#armors_list').unhighlight();
+            $('#armors_list').highlight($(this).val());
+        });
+    });
+
+    /*
+     * -------------------------
+     * Back to top functionality
+     * -------------------------
+     */
+    $(function() {
+        var offset = 220;
+        var duration = 500;
+        $(window).scroll(function() {
+            if ($(this).scrollTop() > offset) {
+                $('.back-to-top').fadeIn(duration);
+            } else {
+                $('.back-to-top').fadeOut(duration);
+            }
+        });
+
+        $('.back-to-top').click(function(event) {
+            event.preventDefault();
+            $('html, body').animate({scrollTop: 0}, duration);
+            return false;
+        });
+    });
 })( jQuery );

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,5 @@
 var profilesKey = 'darksouls3_profiles';
+var stateKey = 'darksouls3_state';
 
 (function($) {
     'use strict';
@@ -12,6 +13,12 @@ var profilesKey = 'darksouls3_profiles';
         }
     };
     var profiles = $.jStorage.get(profilesKey, defaultProfiles);
+
+    var stateStorage = $.jStorage.get(stateKey, {
+        collapsed: {},
+        current_tab: '#tabPlaythrough',
+        hide_completed: false
+    });
 
     jQuery(document).ready(function($) {
 
@@ -167,6 +174,10 @@ var profilesKey = 'darksouls3_profiles';
             $(this).data("hidden", !hidden);
 
             toggleCompletedCheckboxes(!hidden);
+
+            stateStorage.hide_completed = !hidden;
+
+            $.jStorage.set(stateKey, stateStorage);
         });
 
         calculateTotals();
@@ -333,4 +344,43 @@ var profilesKey = 'darksouls3_profiles';
             return false;
         });
     });
+
+    /*
+     * ------------------------------------------
+     * Restore tabs/hidden sections functionality
+     * ------------------------------------------
+     */
+     $(function() {
+        // restore collapsed state on page load
+        $.each(stateStorage.collapsed, function(key, val) {
+            if (val) {
+                $('a[href="' + key + '"]').click();
+            }
+        });
+
+        if (stateStorage.current_tab) {
+            $('.nav.navbar-nav li a[href="' + stateStorage.current_tab + '"]').click();
+        }
+
+        if (typeof stateStorage.hide_completed !== 'undefined' &&
+            stateStorage.hide_completed !== null && stateStorage.hide_completed === true) {
+            $("#toggleHideCompleted").click();
+        }
+
+        // register on click handlers to store state
+        $('a[href$="_col"]').on('click', function(el) {
+            var collapsed_key = $(this).attr('href');
+            var saved_tab_state = !!stateStorage.collapsed[collapsed_key];
+
+            stateStorage.collapsed[$(this).attr('href')] = !saved_tab_state;
+
+            $.jStorage.set(stateKey, stateStorage);
+        });
+
+        $('.nav.navbar-nav li a').on('click', function(el) {
+            stateStorage.current_tab = $(this).attr('href');
+
+            $.jStorage.set(stateKey, stateStorage);
+        });
+     });
 })( jQuery );

--- a/js/main.js
+++ b/js/main.js
@@ -41,7 +41,7 @@ var stateKey = 'darksouls3_state';
               $('[data-id="'+id+'"] label').addClass('stroked');
 
               if ($("#toggleHideCompleted").data("hidden") === true) {
-                $('[data-id="'+id+'"] label').hide();
+                $('[data-id="'+id+'"] label').parent().hide();
               }
             } else {
               $('[data-id="'+id+'"] label').removeClass('stroked');


### PR DESCRIPTION
[preview here](http://cl4ptp.github.io/dark-souls-3-cheat-sheet/)
- The page now saves tab/collapsed section/hide completed state in local storage and restores on page load (issue #45 with tabs and hide completed added on). The state storage is independent of profile storage, but this may not be preferable. Also, there may be bugs...
- Moved the title of the page down so the menu is all one row at the top on desktop displays.
- Fixed a bug where completing an item while "Hide completed" was enabled would not show that item when "Hide completed" was then disabled, only when the page was reloaded.
- Collected embedded Javascript into the `main.js` file so that browsers can use caching to load the page faster.
