### PR TITLE
Added categories filter

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -83,6 +83,11 @@ h3 {
   vertical-align: top;
 }
 
+.btn:focus, .btn.active:focus {
+    outline: none;
+    outline: 0;
+}
+
 /* Icon when the collapsible content is shown */
 .btn-collapse:after {
   font-family: 'Glyphicons Halflings';

--- a/index.html
+++ b/index.html
@@ -66,8 +66,10 @@
     </div>
 
     <div class="tab-content">
-        <!-- Toolbar -->
-        <div class="btn-toolbar" role="toolbar">
+        <!-- PLAYTHROUGH START -->
+        <div class="tab-pane active" id="tabPlaythrough">
+            <!-- Toolbar -->
+            <div class="btn-toolbar" role="toolbar">
             <div class="btn-group" role="group">
                 <button type="button" class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
             </div>
@@ -80,9 +82,7 @@
                 <button type="button" class="btn btn-default" id="togglefilter_materials">&#9745; Materials</button>
                 <button type="button" class="btn btn-default" id="togglefilter_misc">&#9745; Misc</button>
             </div>
-        </div>          
-      <!-- PLAYTHROUGH START -->
-      <div class="tab-pane active" id="tabPlaythrough">
+            </div>    
         <h2>Playthrough Checklist <span id="playthrough_overall_total"></span></h2>
         <ul class="table_of_contents">
           <li><a href="#Cemetery_of_Ash">Cemetery of Ash</a> <span id="playthrough_nav_totals_17"></span></li>

--- a/index.html
+++ b/index.html
@@ -63,16 +63,15 @@
       <p>
         <em>Warning: Contains Spoilers!</em>
       </p>
+      <div class="btn-group" role="group">
+          <button type="button" class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
+      </div>
     </div>
 
     <div class="tab-content">
         <!-- PLAYTHROUGH START -->
         <div class="tab-pane active" id="tabPlaythrough">
             <!-- Toolbar -->
-            <div class="btn-toolbar" role="toolbar">
-            <div class="btn-group" role="group">
-                <button type="button" class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
-            </div>
             <div class="btn-group" role="group">
                 <button type="button" class="btn btn-default" id="togglefilter_quest">&#9745; Quests</button>
                 <button type="button" class="btn btn-default" id="togglefilter_estus">&#9745; Estus</button>
@@ -81,7 +80,6 @@
                 <button type="button" class="btn btn-default" id="togglefilter_ring">&#9745; Rings</button>
                 <button type="button" class="btn btn-default" id="togglefilter_materials">&#9745; Materials</button>
                 <button type="button" class="btn btn-default" id="togglefilter_misc">&#9745; Misc</button>
-            </div>
             </div>    
         <h2>Playthrough Checklist <span id="playthrough_overall_total"></span></h2>
         <ul class="table_of_contents">

--- a/index.html
+++ b/index.html
@@ -66,7 +66,21 @@
     </div>
 
     <div class="tab-content">
-	  <button class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
+        <!-- Toolbar -->
+        <div class="btn-toolbar" role="toolbar">
+            <div class="btn-group" role="group">
+                <button type="button" class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
+            </div>
+            <div class="btn-group" role="group">
+                <button type="button" class="btn btn-default" id="togglefilter_quest" data-hidden="false">[X] Quests</button>
+                <button type="button" class="btn btn-default" id="togglefilter_estus" data-hidden="false">[X] Estus</button>
+                <button type="button" class="btn btn-default" id="togglefilter_weapon" data-hidden="false">[X] Weapons</button>
+                <button type="button" class="btn btn-default" id="togglefilter_armor" data-hidden="false">[X] Armors</button>
+                <button type="button" class="btn btn-default" id="togglefilter_ring" data-hidden="false">[X] Rings</button>
+                <button type="button" class="btn btn-default" id="togglefilter_materials" data-hidden="false">[X] Materials</button>
+                <button type="button" class="btn btn-default" id="togglefilter_misc" data-hidden="false">[X] Misc</button>
+            </div>
+        </div>          
       <!-- PLAYTHROUGH START -->
       <div class="tab-pane active" id="tabPlaythrough">
         <h2>Playthrough Checklist <span id="playthrough_overall_total"></span></h2>
@@ -101,53 +115,53 @@
 
         <h3 id="Cemetery_of_Ash"><a href="#Cemetery_of_Ash_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/Cemetery+of+Ash">Cemetery of Ash</a> <span id="playthrough_totals_17"></span></h3>
         <ul id="Cemetery_of_Ash_col" class="collapse in">
-          <li data-id="playthrough_17_1">From the start head right at the first turn and pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+a+Deserted+Corpse">Soul of a Deserted Corpse</a></li>
-          <li data-id="playthrough_17_2">Loot the corpse on the fountain to obtain the <a href="http://darksouls3.wiki.fextralife.com/Ashen+Estus+Flask"> Ashen Estus Flask</a></li>
-          <li data-id="playthrough_17_3">Turn right after the fountain and head down the path through a flooded passage. Kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Ravenous Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Scale"> Titanite Scale</a> then pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+an+Unknown+Traveler">Soul of an Unknown Traveler</a> from the corspe in the area</li>
-          <li data-id="playthrough_17_4">Head back to the fountain and take the path straight ahead. Climb the cliff and rest at the Cemetery of Ash bonfire to receive the Rest gesture</li>
-          <li data-id="playthrough_17_5">From the bonfire head down the left path and make the jump from the cliff over to the corpse on the tomb to pick up a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Shard"> Titanite Shard</a></li>
-          <li data-id="playthrough_17_6">Take the side ridge down from the large cliff face on the right to pick up five <a href="http://darksouls3.wiki.fextralife.com/Firebomb"> Firebombs</a> from the corpse</li>
-          <li data-id="playthrough_17_7">Back on the main path head through the archway and take the sword embedded in the statue. Kill <a href="http://darksouls3.wiki.fextralife.com/Iudex+Gundyr"> Iudex Gundyr</a> to receive the <a href="http://darksouls3.wiki.fextralife.com/Coiled+Sword"> Coiled Sword</a></li>
-          <li data-id="playthrough_17_8">Congratulate yourself on beating the first boss of Dark Souls 3 and rest at the <a href="http://darksouls3.wiki.fextralife.com/Iudex+Gundyr"> Iudex Gundyr</a> bonfire</li>
-          <li data-id="playthrough_17_9">Continue through the large door and pick up the <a href="http://darksouls3.wiki.fextralife.com/Broken+Straight+Sword"> Broken Straight Sword</a> from the corpse leaning on the tombstone</li>
-          <li data-id="playthrough_17_10">Head over to the large cliff edge and pick up the<a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> at the edge of the ridge</li>
-          <li data-id="playthrough_17_11">Take the left path up the cliff and turn left just before <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine"> Firelink Shrine</a> and grab the <a href="http://darksouls3.wiki.fextralife.com/East-West+Shield"> East-West Shield</a> from the corpse in the tree</li>
-          <li data-id="playthrough_17_12">If you're feeling brave kill <a href="http://darksouls3.wiki.fextralife.com/Sword+Master"> Sword Master Saber</a> to get the <a href="http://darksouls3.wiki.fextralife.com/Uchigatana"> Uchigatana</a>, <a href="http://darksouls3.wiki.fextralife.com/Master's+Attire"> Master's Attire</a>, and <a href="http://darksouls3.wiki.fextralife.com/Master's+Gloves"> Master's Gloves</a> </li>
-          <li data-id="playthrough_17_13">Head back and up the path to the left to pick up an <a href="http://darksouls3.wiki.fextralife.com/Ember"> Ember</a> from a corpse above the entrance above <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a></li>
-          <li data-id="playthrough_17_14">Continue across to the other side picking up a <a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> from a corpse behind a tomb and another <a href="http://darksouls3.wiki.fextralife.com/Ember"> Ember</a> from the lower ridge </li>
-          <li data-id="playthrough_17_15">Go back to the main path and head on in to the central hub of Dark Souls 3, the <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a></li>
+          <li class="f_misc" data-id="playthrough_17_1">From the start head right at the first turn and pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+a+Deserted+Corpse">Soul of a Deserted Corpse</a></li>
+          <li class="f_estus" data-id="playthrough_17_2">Loot the corpse on the fountain to obtain the <a href="http://darksouls3.wiki.fextralife.com/Ashen+Estus+Flask"> Ashen Estus Flask</a></li>
+          <li class="f_mat" data-id="playthrough_17_3">Turn right after the fountain and head down the path through a flooded passage. Kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Ravenous Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Scale"> Titanite Scale</a> then pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+an+Unknown+Traveler">Soul of an Unknown Traveler</a> from the corspe in the area</li>
+          <li class="f_quest" data-id="playthrough_17_4">Head back to the fountain and take the path straight ahead. Climb the cliff and rest at the Cemetery of Ash bonfire to receive the Rest gesture</li>
+          <li class="f_mat" data-id="playthrough_17_5">From the bonfire head down the left path and make the jump from the cliff over to the corpse on the tomb to pick up a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Shard"> Titanite Shard</a></li>
+          <li class="f_misc" data-id="playthrough_17_6">Take the side ridge down from the large cliff face on the right to pick up five <a href="http://darksouls3.wiki.fextralife.com/Firebomb"> Firebombs</a> from the corpse</li>
+          <li class="f_misc" data-id="playthrough_17_7">Back on the main path head through the archway and take the sword embedded in the statue. Kill <a href="http://darksouls3.wiki.fextralife.com/Iudex+Gundyr"> Iudex Gundyr</a> to receive the <a href="http://darksouls3.wiki.fextralife.com/Coiled+Sword"> Coiled Sword</a></li>
+          <li class="f_misc" data-id="playthrough_17_8">Congratulate yourself on beating the first boss of Dark Souls 3 and rest at the <a href="http://darksouls3.wiki.fextralife.com/Iudex+Gundyr"> Iudex Gundyr</a> bonfire</li>
+          <li class="f_misc" data-id="playthrough_17_9">Continue through the large door and pick up the <a href="http://darksouls3.wiki.fextralife.com/Broken+Straight+Sword"> Broken Straight Sword</a> from the corpse leaning on the tombstone</li>
+          <li class="f_misc" data-id="playthrough_17_10">Head over to the large cliff edge and pick up the<a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> at the edge of the ridge</li>
+          <li class="f_wpn" data-id="playthrough_17_11">Take the left path up the cliff and turn left just before <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine"> Firelink Shrine</a> and grab the <a href="http://darksouls3.wiki.fextralife.com/East-West+Shield"> East-West Shield</a> from the corpse in the tree</li>
+          <li class="f_wpn" data-id="playthrough_17_12">If you're feeling brave kill <a href="http://darksouls3.wiki.fextralife.com/Sword+Master"> Sword Master Saber</a> to get the <a href="http://darksouls3.wiki.fextralife.com/Uchigatana"> Uchigatana</a>, <a href="http://darksouls3.wiki.fextralife.com/Master's+Attire"> Master's Attire</a>, and <a href="http://darksouls3.wiki.fextralife.com/Master's+Gloves"> Master's Gloves</a> </li>
+          <li class="f_misc" data-id="playthrough_17_13">Head back and up the path to the left to pick up an <a href="http://darksouls3.wiki.fextralife.com/Ember"> Ember</a> from a corpse above the entrance above <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a></li>
+          <li class="f_misc" data-id="playthrough_17_14">Continue across to the other side picking up a <a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> from a corpse behind a tomb and another <a href="http://darksouls3.wiki.fextralife.com/Ember"> Ember</a> from the lower ridge </li>
+          <li class="f_misc" data-id="playthrough_17_15">Go back to the main path and head on in to the central hub of Dark Souls 3, the <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a></li>
         </ul>
 
         <h3 id="Firelink_Shrine"><a href="#Firelink_Shrine_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a> <span id="playthrough_totals_1"></span></h3>
         <ul id="Firelink_Shrine_col" class="collapse in">
-          <li data-id="playthrough_1_1">Talk to <a href="http://darksouls3.wiki.fextralife.com/Fire+Keeper">Fire Keeper</a></li>
-          <li data-id="playthrough_1_2">Talk to <a href="http://darksouls3.wiki.fextralife.com/Shrine+Handmaid">Shrine Handmaid</a>
+          <li class="f_quest" data-id="playthrough_1_1">Talk to <a href="http://darksouls3.wiki.fextralife.com/Fire+Keeper">Fire Keeper</a></li>
+          <li class="f_quest" data-id="playthrough_1_2">Talk to <a href="http://darksouls3.wiki.fextralife.com/Shrine+Handmaid">Shrine Handmaid</a>
             <ul>
               <li data-id="playthrough_1_2_1">She sells </li>
             </ul>
           </li>
-          <li data-id="playthrough_1_3">Talk to <a href="http://darksouls3.wiki.fextralife.com/Hawkwood">Hawkwood</a> to receive Collapse Gesture</li>
-          <li data-id="playthrough_1_4">Talk to <a href="http://darksouls3.wiki.fextralife.com/Blacksmith+Andre">Blacksmith Andre</a> to receive Hurrah! Gesture</li>
-          <li data-id="playthrough_1_5">Go out the top of <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink shrine</a> and pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+a+Deserted+Corpse">Soul of a Deserted Corpse</a> from the corpse next to the small decrepit tower </li>
-          <li data-id="playthrough_1_6">When you have the <a href="http://darksouls3.wiki.fextralife.com/Tower+Key">Tower Key</a> unlock the small decrepit tower and head up to the bridge leading to the Bell Tower</li>
-          <li data-id="playthrough_1_7">Roll off the bridge onto the <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a> roof and kick down the ladder shortcut</li>
-          <li data-id="playthrough_1_8">Just behind the roof kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Twinkling+Titanite"> Twinkling Titanite</a> </li>
-          <li data-id="playthrough_1_9">Pick up the <a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> from the lower part of the roof</li>
-          <li data-id="playthrough_1_10">Inside the roof pick up the <a href="http://darksouls3.wiki.fextralife.com/Estus+Shard"> Estus Flask Shard</a> from up in the rafters</li>
-          <li data-id="playthrough_1_11">Trade any possible item with <a href="http://darksouls3.wiki.fextralife.com/Pickle+Pee,+Pump-a-Rum+Crow"> Pickle-Pee, Pump-a-Rum</a> crow to receive the Call Over gesture</li>
-          <li data-id="playthrough_1_12">Hit the <a href="http://darksouls3.wiki.fextralife.com/Illusory+Walls">Illusory Wall</a> at the back of the rafters and drop down to get the <a href="http://darksouls3.wiki.fextralife.com/Covetous+Silver+Serpent+Ring">Covetous Silver Serpent Ring</a> from the chest</li>
-          <li data-id="playthrough_1_13">Head into the Bell Tower and look down to the left. Carefully jump down to the tombstone and pick up the <a href="http://darksouls3.wiki.fextralife.com/Fire+Keeper+Set">Fire Keeper Set </a> from the corpse</li>
-          <li data-id="playthrough_1_14">Make your way down to the bottom and pick up the <a href="http://darksouls3.wiki.fextralife.com/Estus+Ring"> Estus Ring </a> from another corpse</li>
-          <li data-id="playthrough_1_15">Open the door and head back to the Bell Tower. Go up the lift and <a href="http://darksouls3.wiki.fextralife.com/Unbreakable+Patches"> Patches </a> may close it behind you depending on progress </li>
-          <li data-id="playthrough_1_16">At the top of the Bell Tower pick up the <a href="http://darksouls3.wiki.fextralife.com/Fire%20Keeper+Soul"> Fire Keeper Soul </a> </li>
+          <li class="f_quest" data-id="playthrough_1_3">Talk to <a href="http://darksouls3.wiki.fextralife.com/Hawkwood">Hawkwood</a> to receive Collapse Gesture</li>
+          <li class="f_quest" data-id="playthrough_1_4">Talk to <a href="http://darksouls3.wiki.fextralife.com/Blacksmith+Andre">Blacksmith Andre</a> to receive Hurrah! Gesture</li>
+          <li class="f_misc" data-id="playthrough_1_5">Go out the top of <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink shrine</a> and pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+a+Deserted+Corpse">Soul of a Deserted Corpse</a> from the corpse next to the small decrepit tower </li>
+          <li class="f_misc" data-id="playthrough_1_6">When you have the <a href="http://darksouls3.wiki.fextralife.com/Tower+Key">Tower Key</a> unlock the small decrepit tower and head up to the bridge leading to the Bell Tower</li>
+          <li class="f_misc" data-id="playthrough_1_7">Roll off the bridge onto the <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a> roof and kick down the ladder shortcut</li>
+          <li class="f_mat" data-id="playthrough_1_8">Just behind the roof kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Twinkling+Titanite"> Twinkling Titanite</a> </li>
+          <li class="f_misc" data-id="playthrough_1_9">Pick up the <a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> from the lower part of the roof</li>
+          <li class="f_estus" data-id="playthrough_1_10">Inside the roof pick up the <a href="http://darksouls3.wiki.fextralife.com/Estus+Shard"> Estus Flask Shard</a> from up in the rafters</li>
+          <li class="f_quest" data-id="playthrough_1_11">Trade any possible item with <a href="http://darksouls3.wiki.fextralife.com/Pickle+Pee,+Pump-a-Rum+Crow"> Pickle-Pee, Pump-a-Rum</a> crow to receive the Call Over gesture</li>
+          <li class="f_ring" data-id="playthrough_1_12">Hit the <a href="http://darksouls3.wiki.fextralife.com/Illusory+Walls">Illusory Wall</a> at the back of the rafters and drop down to get the <a href="http://darksouls3.wiki.fextralife.com/Covetous+Silver+Serpent+Ring">Covetous Silver Serpent Ring</a> from the chest</li>
+          <li class="f_armor" data-id="playthrough_1_13">Head into the Bell Tower and look down to the left. Carefully jump down to the tombstone and pick up the <a href="http://darksouls3.wiki.fextralife.com/Fire+Keeper+Set">Fire Keeper Set </a> from the corpse</li>
+          <li class="f_ring" data-id="playthrough_1_14">Make your way down to the bottom and pick up the <a href="http://darksouls3.wiki.fextralife.com/Estus+Ring"> Estus Ring </a> from another corpse</li>
+          <li class="f_quest" data-id="playthrough_1_15">Open the door and head back to the Bell Tower. Go up the lift and <a href="http://darksouls3.wiki.fextralife.com/Unbreakable+Patches"> Patches </a> may close it behind you depending on progress </li>
+          <li class="f_quest" data-id="playthrough_1_16">At the top of the Bell Tower pick up the <a href="http://darksouls3.wiki.fextralife.com/Fire%20Keeper+Soul"> Fire Keeper Soul </a> </li>
         </ul>
 
         <h3 id="High_Wall_of_Lothric"><a href="#High_Wall_of_Lothric_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/High+Wall+of+Lothric">High Wall of Lothric</a> <span id="playthrough_totals_2"></span></h3>
         <ul id="High_Wall_of_Lothric_col" class="collapse in">
-          <li data-id="playthrough_2_1">Free Greirat below the Tower on the Wall bonfire with the Cell Key, which is found at the bottom of the building that is past the same bonfire. Talk to him and agreed to give the Blue Tearstone Ring to Loretta. He will then return to Firelink Shrine.</li>
-          <li data-id="playthrough_2_2">Andre Progress: Grab Estus Shard on an altar in the room where you get the Cell Key.</li>
-          <li data-id="playthrough_2_3">After lighting the Tower on the Wall bonfire, return to Firelink Shrine and talk to Leonhard, who will give you 5 Cracked Red-Eye Orbs. He'll be by Prince Lothric's throne, if he isn't at this point, try killing Vordt and check again.</li>
-          <li data-id="playthrough_2_4">Talk to Emma, who is found the opposite direction of where Vordt is located, to receive the Way of Blue covenant and the Small Lothric Banner, which allows you to access the Undead Settlement.</li>
+          <li class="f_quest" data-id="playthrough_2_1">Free Greirat below the Tower on the Wall bonfire with the Cell Key, which is found at the bottom of the building that is past the same bonfire. Talk to him and agreed to give the Blue Tearstone Ring to Loretta. He will then return to Firelink Shrine.</li>
+          <li class="f_estus" data-id="playthrough_2_2">Andre Progress: Grab Estus Shard on an altar in the room where you get the Cell Key.</li>
+          <li class="f_quest" data-id="playthrough_2_3">After lighting the Tower on the Wall bonfire, return to Firelink Shrine and talk to Leonhard, who will give you 5 Cracked Red-Eye Orbs. He'll be by Prince Lothric's throne, if he isn't at this point, try killing Vordt and check again.</li>
+          <li class="f_quest" data-id="playthrough_2_4">Talk to Emma, who is found the opposite direction of where Vordt is located, to receive the Way of Blue covenant and the Small Lothric Banner, which allows you to access the Undead Settlement.</li>
         </ul>
 
         <h3 id="Undead_Settlement"><a href="#Undead_Settlement_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/Undead+Settlement">Undead Settlement</a> <span id="playthrough_totals_3"></span></h3>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             <div class="btn-group" role="group">
                 <button type="button" class="btn btn-default" id="togglefilter_quest">&#9745; Quests</button>
                 <button type="button" class="btn btn-default" id="togglefilter_estus">&#9745; Estus</button>
-                <button type="button" class="btn btn-default" id="togglefilter_weapon">&#9745; Weapons</button>
+                <button type="button" class="btn btn-default" id="togglefilter_weapon">&#9745; Weapons/Shields</button>
                 <button type="button" class="btn btn-default" id="togglefilter_armor">&#9745; Armors</button>
                 <button type="button" class="btn btn-default" id="togglefilter_ring">&#9745; Rings</button>
                 <button type="button" class="btn btn-default" id="togglefilter_materials">&#9745; Materials</button>

--- a/index.html
+++ b/index.html
@@ -72,13 +72,13 @@
                 <button type="button" class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
             </div>
             <div class="btn-group" role="group">
-                <button type="button" class="btn btn-default" id="togglefilter_quest" data-hidden="false">[X] Quests</button>
-                <button type="button" class="btn btn-default" id="togglefilter_estus" data-hidden="false">[X] Estus</button>
-                <button type="button" class="btn btn-default" id="togglefilter_weapon" data-hidden="false">[X] Weapons</button>
-                <button type="button" class="btn btn-default" id="togglefilter_armor" data-hidden="false">[X] Armors</button>
-                <button type="button" class="btn btn-default" id="togglefilter_ring" data-hidden="false">[X] Rings</button>
-                <button type="button" class="btn btn-default" id="togglefilter_materials" data-hidden="false">[X] Materials</button>
-                <button type="button" class="btn btn-default" id="togglefilter_misc" data-hidden="false">[X] Misc</button>
+                <button type="button" class="btn btn-default" id="togglefilter_quest">[X] Quests</button>
+                <button type="button" class="btn btn-default" id="togglefilter_estus">[X] Estus</button>
+                <button type="button" class="btn btn-default" id="togglefilter_weapon">[X] Weapons</button>
+                <button type="button" class="btn btn-default" id="togglefilter_armor">[X] Armors</button>
+                <button type="button" class="btn btn-default" id="togglefilter_ring">[X] Rings</button>
+                <button type="button" class="btn btn-default" id="togglefilter_materials">[X] Materials</button>
+                <button type="button" class="btn btn-default" id="togglefilter_misc">[X] Misc</button>
             </div>
         </div>          
       <!-- PLAYTHROUGH START -->
@@ -117,7 +117,7 @@
         <ul id="Cemetery_of_Ash_col" class="collapse in">
           <li class="f_misc" data-id="playthrough_17_1">From the start head right at the first turn and pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+a+Deserted+Corpse">Soul of a Deserted Corpse</a></li>
           <li class="f_estus" data-id="playthrough_17_2">Loot the corpse on the fountain to obtain the <a href="http://darksouls3.wiki.fextralife.com/Ashen+Estus+Flask"> Ashen Estus Flask</a></li>
-          <li class="f_mat" data-id="playthrough_17_3">Turn right after the fountain and head down the path through a flooded passage. Kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Ravenous Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Scale"> Titanite Scale</a> then pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+an+Unknown+Traveler">Soul of an Unknown Traveler</a> from the corspe in the area</li>
+          <li class="f_mat f_misc" data-id="playthrough_17_3">Turn right after the fountain and head down the path through a flooded passage. Kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Ravenous Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Scale"> Titanite Scale</a> then pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+an+Unknown+Traveler">Soul of an Unknown Traveler</a> from the corspe in the area</li>
           <li class="f_quest" data-id="playthrough_17_4">Head back to the fountain and take the path straight ahead. Climb the cliff and rest at the Cemetery of Ash bonfire to receive the Rest gesture</li>
           <li class="f_mat" data-id="playthrough_17_5">From the bonfire head down the left path and make the jump from the cliff over to the corpse on the tomb to pick up a <a href="http://darksouls3.wiki.fextralife.com/Titanite+Shard"> Titanite Shard</a></li>
           <li class="f_misc" data-id="playthrough_17_6">Take the side ridge down from the large cliff face on the right to pick up five <a href="http://darksouls3.wiki.fextralife.com/Firebomb"> Firebombs</a> from the corpse</li>
@@ -126,7 +126,7 @@
           <li class="f_misc" data-id="playthrough_17_9">Continue through the large door and pick up the <a href="http://darksouls3.wiki.fextralife.com/Broken+Straight+Sword"> Broken Straight Sword</a> from the corpse leaning on the tombstone</li>
           <li class="f_misc" data-id="playthrough_17_10">Head over to the large cliff edge and pick up the<a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> at the edge of the ridge</li>
           <li class="f_wpn" data-id="playthrough_17_11">Take the left path up the cliff and turn left just before <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine"> Firelink Shrine</a> and grab the <a href="http://darksouls3.wiki.fextralife.com/East-West+Shield"> East-West Shield</a> from the corpse in the tree</li>
-          <li class="f_wpn" data-id="playthrough_17_12">If you're feeling brave kill <a href="http://darksouls3.wiki.fextralife.com/Sword+Master"> Sword Master Saber</a> to get the <a href="http://darksouls3.wiki.fextralife.com/Uchigatana"> Uchigatana</a>, <a href="http://darksouls3.wiki.fextralife.com/Master's+Attire"> Master's Attire</a>, and <a href="http://darksouls3.wiki.fextralife.com/Master's+Gloves"> Master's Gloves</a> </li>
+          <li class="f_wpn f_armor" data-id="playthrough_17_12">If you're feeling brave kill <a href="http://darksouls3.wiki.fextralife.com/Sword+Master"> Sword Master Saber</a> to get the <a href="http://darksouls3.wiki.fextralife.com/Uchigatana"> Uchigatana</a>, <a href="http://darksouls3.wiki.fextralife.com/Master's+Attire"> Master's Attire</a>, and <a href="http://darksouls3.wiki.fextralife.com/Master's+Gloves"> Master's Gloves</a> </li>
           <li class="f_misc" data-id="playthrough_17_13">Head back and up the path to the left to pick up an <a href="http://darksouls3.wiki.fextralife.com/Ember"> Ember</a> from a corpse above the entrance above <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a></li>
           <li class="f_misc" data-id="playthrough_17_14">Continue across to the other side picking up a <a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> from a corpse behind a tomb and another <a href="http://darksouls3.wiki.fextralife.com/Ember"> Ember</a> from the lower ridge </li>
           <li class="f_misc" data-id="playthrough_17_15">Go back to the main path and head on in to the central hub of Dark Souls 3, the <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a></li>
@@ -143,7 +143,7 @@
           <li class="f_quest" data-id="playthrough_1_3">Talk to <a href="http://darksouls3.wiki.fextralife.com/Hawkwood">Hawkwood</a> to receive Collapse Gesture</li>
           <li class="f_quest" data-id="playthrough_1_4">Talk to <a href="http://darksouls3.wiki.fextralife.com/Blacksmith+Andre">Blacksmith Andre</a> to receive Hurrah! Gesture</li>
           <li class="f_misc" data-id="playthrough_1_5">Go out the top of <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink shrine</a> and pick up the <a href="http://darksouls3.wiki.fextralife.com/Soul+of+a+Deserted+Corpse">Soul of a Deserted Corpse</a> from the corpse next to the small decrepit tower </li>
-          <li class="f_misc" data-id="playthrough_1_6">When you have the <a href="http://darksouls3.wiki.fextralife.com/Tower+Key">Tower Key</a> unlock the small decrepit tower and head up to the bridge leading to the Bell Tower</li>
+          <li class="f_quest" data-id="playthrough_1_6">When you have the <a href="http://darksouls3.wiki.fextralife.com/Tower+Key">Tower Key</a> unlock the small decrepit tower and head up to the bridge leading to the Bell Tower</li>
           <li class="f_misc" data-id="playthrough_1_7">Roll off the bridge onto the <a href="http://darksouls3.wiki.fextralife.com/Firelink+Shrine">Firelink Shrine</a> roof and kick down the ladder shortcut</li>
           <li class="f_mat" data-id="playthrough_1_8">Just behind the roof kill the <a href="http://darksouls3.wiki.fextralife.com/Crystal+Lizard"> Crystal Lizard</a> to get a <a href="http://darksouls3.wiki.fextralife.com/Twinkling+Titanite"> Twinkling Titanite</a> </li>
           <li class="f_misc" data-id="playthrough_1_9">Pick up the <a href="http://darksouls3.wiki.fextralife.com/Homeward+Bone"> Homeward Bone</a> from the lower part of the roof</li>

--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
           <li data-id="playthrough_10_4">Continue further and you'll find a chest. The wall behind the chest is a illusory wall, so activate it and you'll arrive at the Untended Graves</li>
         </ul>
 
-        <h3 id=">Untended_Graves"><a href="#Untended_Graves_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/Untended+Graves">Untended Graves</a> <span id="playthrough_totals_11"></span></h3>
+        <h3 id="Untended_Graves"><a href="#Untended_Graves_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="http://darksouls3.wiki.fextralife.com/Untended+Graves">Untended Graves</a> <span id="playthrough_totals_11"></span></h3>
         <ul id="Untended_Graves_col" class="collapse in">
           <li data-id="playthrough_11_1">Fire Keeper Progress: At the very end of the Untended Graves when you reach the alternate version of Firelink Shrine, activate the illusory wall to where Irina normally is and you'll find the Eyes of a Fire Keeper. These can be given to the Fire Keeper to trigger the End of Fire ending</li>
           <li data-id="playthrough_11_2">Shrine Handmaid Progress: There is another Shrine Handmaid here that sells the Wolf Knight Armor Set, the Priestess Ring, and other merchandise. Unlike the regular Handmaid, if you kill this one, she will not respawn, so be careful</li>

--- a/index.html
+++ b/index.html
@@ -72,13 +72,13 @@
                 <button type="button" class="btn btn-default" id="toggleHideCompleted" data-hidden="false">Hide completed</button>
             </div>
             <div class="btn-group" role="group">
-                <button type="button" class="btn btn-default" id="togglefilter_quest">[X] Quests</button>
-                <button type="button" class="btn btn-default" id="togglefilter_estus">[X] Estus</button>
-                <button type="button" class="btn btn-default" id="togglefilter_weapon">[X] Weapons</button>
-                <button type="button" class="btn btn-default" id="togglefilter_armor">[X] Armors</button>
-                <button type="button" class="btn btn-default" id="togglefilter_ring">[X] Rings</button>
-                <button type="button" class="btn btn-default" id="togglefilter_materials">[X] Materials</button>
-                <button type="button" class="btn btn-default" id="togglefilter_misc">[X] Misc</button>
+                <button type="button" class="btn btn-default" id="togglefilter_quest">&#9745; Quests</button>
+                <button type="button" class="btn btn-default" id="togglefilter_estus">&#9745; Estus</button>
+                <button type="button" class="btn btn-default" id="togglefilter_weapon">&#9745; Weapons</button>
+                <button type="button" class="btn btn-default" id="togglefilter_armor">&#9745; Armors</button>
+                <button type="button" class="btn btn-default" id="togglefilter_ring">&#9745; Rings</button>
+                <button type="button" class="btn btn-default" id="togglefilter_materials">&#9745; Materials</button>
+                <button type="button" class="btn btn-default" id="togglefilter_misc">&#9745; Misc</button>
             </div>
         </div>          
       <!-- PLAYTHROUGH START -->

--- a/js/main.js
+++ b/js/main.js
@@ -311,6 +311,9 @@ var stateKey = 'darksouls3_state';
             if (hide === true) {
                 $(this).hide();
             } else {
+                if ($(this).is('li') && canFilter($(this).closest('li'))) {
+                    return;
+                }
                 $(this).show();
             }
         });

--- a/js/main.js
+++ b/js/main.js
@@ -167,19 +167,15 @@ var stateKey = 'darksouls3_state';
 
         $("#toggleHideCompleted").click(function() {
             var hidden = $(this).data("hidden");
-
             if (hidden === true) {
                 $(this).text("Hide completed");
             } else {
                 $(this).text("Show completed");
             }
-
             $(this).data("hidden", !hidden);
-
+            $(this).button('toggle');
             toggleCompletedCheckboxes(!hidden);
-
             stateStorage.hide_completed = !hidden;
-
             $.jStorage.set(stateKey, stateStorage);
         });
 
@@ -257,7 +253,7 @@ var stateKey = 'darksouls3_state';
                         break;
                     }
                     if (checkbox.is(':hidden') && checkbox.prop('id').match(regexFilter)) {
-                       continue;
+                        continue;
                     }
                     count++;
                     overallCount++;

--- a/js/main.js
+++ b/js/main.js
@@ -180,6 +180,42 @@ var stateKey = 'darksouls3_state';
             $.jStorage.set(stateKey, stateStorage);
         });
 
+        $("#togglefilter_quest").click(function() {
+            toggleFilterButton($(this), "[X] Quests", "[ ] Quests");
+            toggleFilteredClasses("f_quest");
+            calculateTotals();
+        });
+        $("#togglefilter_estus").click(function() {
+            toggleFilterButton($(this), "[X] Estus", "[ ] Estus");
+            toggleFilteredClasses("f_estus");
+            calculateTotals();
+        });
+        $("#togglefilter_weapon").click(function() {
+            toggleFilterButton($(this), "[X] Weapons", "[ ] Weapons");
+            toggleFilteredClasses("f_wpn");
+            calculateTotals();
+        });
+        $("#togglefilter_armor").click(function() {
+            toggleFilterButton($(this), "[X] Armors", "[ ] Armors");
+            toggleFilteredClasses("f_armor");
+            calculateTotals();
+        });
+        $("#togglefilter_ring").click(function() {
+            toggleFilterButton($(this), "[X] Rings", "[ ] Rings");
+            toggleFilteredClasses("f_ring");
+            calculateTotals();
+        });
+        $("#togglefilter_materials").click(function() {
+            toggleFilterButton($(this), "[X] Materials", "[ ] Materials");
+            toggleFilteredClasses("f_mat");
+            calculateTotals();
+        });
+        $("#togglefilter_misc").click(function() {
+            toggleFilterButton($(this), "[X] Misc", "[ ] Misc");
+            toggleFilteredClasses("f_misc");
+            calculateTotals();
+        });
+
         calculateTotals();
 
     });
@@ -216,12 +252,17 @@ var stateKey = 'darksouls3_state';
             var overallCount = 0, overallChecked = 0;
             $('[id^="' + type + '_totals_"]').each(function(index) {
                 var regex = new RegExp(type + '_totals_(.*)');
+                var regexFilter = new RegExp('^playthrough_(.*)');
                 var i = parseInt(this.id.match(regex)[1]);
                 var count = 0, checked = 0;
                 for (var j = 1; ; j++) {
                     var checkbox = $('#' + type + '_' + i + '_' + j);
                     if (checkbox.length === 0) {
                         break;
+                    }
+                    if (checkbox.is(':hidden') && checkbox.prop('id').match(regexFilter)) {
+                       console.log(checkbox.prop('id'));
+                       continue;
                     }
                     count++;
                     overallCount++;
@@ -281,6 +322,22 @@ var stateKey = 'darksouls3_state';
             } else {
                 $(this).show();
             }
+        });
+    }
+
+    function toggleFilterButton(button, shown_txt, hidden_txt) {
+        var hidden = button.data("hidden");
+        if (hidden) {
+            button.text(shown_txt);
+        } else {
+            button.text(hidden_txt);
+        }
+        button.data("hidden", !hidden);
+    }
+
+    function toggleFilteredClasses(str) {
+        $("li." + str).each(function() {
+             $(this).toggle();
         });
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -188,7 +188,7 @@ var stateKey = 'darksouls3_state';
             toggleFilteredClasses("f_estus");
         });
         $("#togglefilter_weapon").click(function() {
-            filter_bools[2] = toggleFilterButton($(this), filter_bools[2], "\u2611 Weapons", "\u2610 Weapons");
+            filter_bools[2] = toggleFilterButton($(this), filter_bools[2], "\u2611 Weapons/Shields", "\u2610 Weapons/Shields");
             toggleFilteredClasses("f_wpn");
         });
         $("#togglefilter_armor").click(function() {

--- a/js/main.js
+++ b/js/main.js
@@ -252,7 +252,7 @@ var stateKey = 'darksouls3_state';
                     if (checkbox.length === 0) {
                         break;
                     }
-                    if (checkbox.is(':hidden') && checkbox.prop('id').match(regexFilter)) {
+                    if (checkbox.is(':hidden') && checkbox.prop('id').match(regexFilter) && canFilter(checkbox.closest('li'))) {
                         continue;
                     }
                     count++;

--- a/js/main.js
+++ b/js/main.js
@@ -311,7 +311,8 @@ var stateKey = 'darksouls3_state';
             if (hide === true) {
                 $(this).hide();
             } else {
-                if ($(this).is('li') && canFilter($(this).closest('li'))) {
+                var regexFilter = new RegExp('^playthrough_(.*)');
+                if ($(this).is('li') && $(this).closest('li').attr('data-id').match(regexFilter) && canFilter($(this).closest('li'))) {
                     return;
                 }
                 $(this).show();

--- a/js/main.js
+++ b/js/main.js
@@ -331,6 +331,9 @@ var stateKey = 'darksouls3_state';
 
     function canFilter(entry) {
         var regexFilter = new RegExp('^f_(.*)');
+        if (entry.hasClass('') === true) {
+            return true;
+        }
         var classList = entry.attr('class').split(/\s+/);
         for (var i = 0; i < classList.length; i++) {
             if (!classList[i].match(regexFilter)) {

--- a/js/main.js
+++ b/js/main.js
@@ -20,6 +20,9 @@ var stateKey = 'darksouls3_state';
         hide_completed: false
     });
 
+    var filter_categ = ["f_quest", "f_estus", "f_wpn", "f_armor", "f_ring", "f_mat", "f_misc"];
+    var filter_bools = [false, false, false, false, false, false, false];
+
     jQuery(document).ready(function($) {
 
         $('ul li li[data-id], ul li[data-id]').each(function(index) {
@@ -181,39 +184,32 @@ var stateKey = 'darksouls3_state';
         });
 
         $("#togglefilter_quest").click(function() {
-            toggleFilterButton($(this), "[X] Quests", "[ ] Quests");
+            filter_bools[0] = toggleFilterButton($(this), filter_bools[0], "[X] Quests", "[ ] Quests");
             toggleFilteredClasses("f_quest");
-            calculateTotals();
         });
         $("#togglefilter_estus").click(function() {
-            toggleFilterButton($(this), "[X] Estus", "[ ] Estus");
+            filter_bools[1] = toggleFilterButton($(this), filter_bools[1], "[X] Estus", "[ ] Estus");
             toggleFilteredClasses("f_estus");
-            calculateTotals();
         });
         $("#togglefilter_weapon").click(function() {
-            toggleFilterButton($(this), "[X] Weapons", "[ ] Weapons");
+            filter_bools[2] = toggleFilterButton($(this), filter_bools[2], "[X] Weapons", "[ ] Weapons");
             toggleFilteredClasses("f_wpn");
-            calculateTotals();
         });
         $("#togglefilter_armor").click(function() {
-            toggleFilterButton($(this), "[X] Armors", "[ ] Armors");
+            filter_bools[3] = toggleFilterButton($(this), filter_bools[3], "[X] Armors", "[ ] Armors");
             toggleFilteredClasses("f_armor");
-            calculateTotals();
         });
         $("#togglefilter_ring").click(function() {
-            toggleFilterButton($(this), "[X] Rings", "[ ] Rings");
+            filter_bools[4] = toggleFilterButton($(this), filter_bools[4], "[X] Rings", "[ ] Rings");
             toggleFilteredClasses("f_ring");
-            calculateTotals();
         });
         $("#togglefilter_materials").click(function() {
-            toggleFilterButton($(this), "[X] Materials", "[ ] Materials");
+            filter_bools[5] = toggleFilterButton($(this), filter_bools[5], "[X] Materials", "[ ] Materials");
             toggleFilteredClasses("f_mat");
-            calculateTotals();
         });
         $("#togglefilter_misc").click(function() {
-            toggleFilterButton($(this), "[X] Misc", "[ ] Misc");
+            filter_bools[6] = toggleFilterButton($(this), filter_bools[6], "[X] Misc", "[ ] Misc");
             toggleFilteredClasses("f_misc");
-            calculateTotals();
         });
 
         calculateTotals();
@@ -261,7 +257,6 @@ var stateKey = 'darksouls3_state';
                         break;
                     }
                     if (checkbox.is(':hidden') && checkbox.prop('id').match(regexFilter)) {
-                       console.log(checkbox.prop('id'));
                        continue;
                     }
                     count++;
@@ -325,20 +320,42 @@ var stateKey = 'darksouls3_state';
         });
     }
 
-    function toggleFilterButton(button, shown_txt, hidden_txt) {
-        var hidden = button.data("hidden");
-        if (hidden) {
+    function toggleFilterButton(button, f_hidden, shown_txt, hidden_txt) {
+        if (f_hidden) {
             button.text(shown_txt);
         } else {
             button.text(hidden_txt);
         }
-        button.data("hidden", !hidden);
+        button.button('toggle');
+        return !f_hidden;
+    }
+
+    function canFilter(entry) {
+        var regexFilter = new RegExp('^f_(.*)');
+        var classList = entry.attr('class').split(/\s+/);
+        for (var i = 0; i < classList.length; i++) {
+            if (!classList[i].match(regexFilter)) {
+                continue;
+            }
+            var filterIndex = $.inArray(classList[i] , filter_categ);
+            if(filterIndex !== -1) {
+                if(!filter_bools[filterIndex]) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     function toggleFilteredClasses(str) {
         $("li." + str).each(function() {
-             $(this).toggle();
+            if(canFilter($(this))) {
+                $(this).hide();
+            } else {
+                $(this).show();
+            }
         });
+        calculateTotals();
     }
 
     /*

--- a/js/main.js
+++ b/js/main.js
@@ -180,31 +180,31 @@ var stateKey = 'darksouls3_state';
         });
 
         $("#togglefilter_quest").click(function() {
-            filter_bools[0] = toggleFilterButton($(this), filter_bools[0], "[X] Quests", "[ ] Quests");
+            filter_bools[0] = toggleFilterButton($(this), filter_bools[0], "\u2611 Quests", "\u2610 Quests");
             toggleFilteredClasses("f_quest");
         });
         $("#togglefilter_estus").click(function() {
-            filter_bools[1] = toggleFilterButton($(this), filter_bools[1], "[X] Estus", "[ ] Estus");
+            filter_bools[1] = toggleFilterButton($(this), filter_bools[1], "\u2611 Estus", "\u2610 Estus");
             toggleFilteredClasses("f_estus");
         });
         $("#togglefilter_weapon").click(function() {
-            filter_bools[2] = toggleFilterButton($(this), filter_bools[2], "[X] Weapons", "[ ] Weapons");
+            filter_bools[2] = toggleFilterButton($(this), filter_bools[2], "\u2611 Weapons", "\u2610 Weapons");
             toggleFilteredClasses("f_wpn");
         });
         $("#togglefilter_armor").click(function() {
-            filter_bools[3] = toggleFilterButton($(this), filter_bools[3], "[X] Armors", "[ ] Armors");
+            filter_bools[3] = toggleFilterButton($(this), filter_bools[3], "\u2611 Armors", "\u2610 Armors");
             toggleFilteredClasses("f_armor");
         });
         $("#togglefilter_ring").click(function() {
-            filter_bools[4] = toggleFilterButton($(this), filter_bools[4], "[X] Rings", "[ ] Rings");
+            filter_bools[4] = toggleFilterButton($(this), filter_bools[4], "\u2611 Rings", "\u2610 Rings");
             toggleFilteredClasses("f_ring");
         });
         $("#togglefilter_materials").click(function() {
-            filter_bools[5] = toggleFilterButton($(this), filter_bools[5], "[X] Materials", "[ ] Materials");
+            filter_bools[5] = toggleFilterButton($(this), filter_bools[5], "\u2611 Materials", "\u2610 Materials");
             toggleFilteredClasses("f_mat");
         });
         $("#togglefilter_misc").click(function() {
-            filter_bools[6] = toggleFilterButton($(this), filter_bools[6], "[X] Misc", "[ ] Misc");
+            filter_bools[6] = toggleFilterButton($(this), filter_bools[6], "\u2611 Misc", "\u2610 Misc");
             toggleFilteredClasses("f_misc");
         });
 


### PR DESCRIPTION
# Changes
1. Added button toolbar in playthrough to filter entries by categories (using classes).
2. An entry can have more than on category. It will only be hidden if all of them are hidden.
3. Counters will ignore filtered entries.
4. Changed Hide Completed to avoid conflicts with filters.
5. Moved the "Hide Completed" button in the same toolbar, so it only show up in the playthrough  tab.
6. Added some classes to the first entries to show how it work.
# Notes
- As talked about in #54, we may have to rename or add categories to fit the editors need.
- I fixed all the major bugs I saw. I hope I didn't miss something big.
- Right now states of the filter are not stored. It should be possible but It's not critical.

[Pull Request Web Preview](http://algent.github.io/dark-souls-3-cheat-sheet/)
