### PR TITLE
Bugfix for Chrome

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -499,6 +499,9 @@ var profilesKey = 'darksouls3_profiles';
      * ------------------------------------------
      */
      $(function() {
+        // reset `Hide completed` button state (otherwise Chrome bugs out)
+        $('#toggleHideCompleted').attr('checked', false);
+
         // restore collapsed state on page load
         restoreState(profiles.current);
 


### PR DESCRIPTION
[Pull Request Web Preview](https://cl4ptp.github.io/dark-souls-3-cheat-sheet/)
# Changes

Fix bug in Chrome where restoring the checklist tab would bug out `Hide Completed` state, fixing #132.
