### PR TITLE
fixes #143 filtering by category

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -425,9 +425,9 @@ var profilesKey = 'darksouls3_profiles';
     function toggleFilteredClasses(str) {
         $("li." + str).each(function() {
             if(canFilter($(this))) {
-                $(this).hide();
+                $(this).css('display', 'none');
             } else {
-                $(this).show();
+                $(this).css('display', '');
             }
         });
     }


### PR DESCRIPTION
The CSS used by `.show()` to display items was overriding the CSS used by Jets to filter the items. As such, if any item had ever been hidden and then unhidden, it could never be filtered.
