### PR TITLE
Texfield Import/Export to allow Steam overlay browser export.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -132,3 +132,8 @@ input[type="checkbox"]:checked ~ .glyphicon-eye-close { display: inline-block; }
 input[type="checkbox"] ~ .glyphicon-eye-open { display: inline-block; }
 
 input[type="checkbox"]:checked ~ .glyphicon-eye-open { display: none; }
+
+textarea#profileText {
+  width:100%;
+  height:15em;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -134,6 +134,6 @@ input[type="checkbox"] ~ .glyphicon-eye-open { display: inline-block; }
 input[type="checkbox"]:checked ~ .glyphicon-eye-open { display: none; }
 
 textarea#profileText {
-  width:100%;
-  height:15em;
+  height: 15em;
+  resize: vertical;
 }

--- a/index.html
+++ b/index.html
@@ -2538,7 +2538,7 @@
             </form>
           </div>
           <div class="col col-xs-12">
-            <textarea id="profileText" class="form-control" placeholder="Paste your profile information here to import it as text. Press 'Export Text' to get your currently saved profiles." ></textarea>
+            <textarea id="profileText" class="form-control"></textarea>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -2528,12 +2528,12 @@
           <div class="col-xs-12 col-sm-8 col-md-6">
             <form class="form-inline">
               <span class="btn-group pull-left">
-                <button class="btn btn-default" type="button" id="profileImport">Import File</button>
-                <button class="btn btn-default" type="button" id="profileExport">Export File</button>
+                <button class="btn btn-default" type="button" id="profileImport">Import file</button>
+                <button class="btn btn-default" type="button" id="profileExport">Export file</button>
               </span>
               <span class="btn-group pull-right">
-                <button class="btn btn-default" type="button" id="profileImportText">Import Text</button>
-                <button class="btn btn-default" type="button" id="profileExportText">Export Text</button>
+                <button class="btn btn-default" type="button" id="profileImportText">Import textbox</button>
+                <button class="btn btn-default" type="button" id="profileExportText">Export clipboard</button>
               </span>
             </form>
           </div>

--- a/index.html
+++ b/index.html
@@ -2519,10 +2519,10 @@
               <button class="btn btn-default" type="button" id="profileEdit">Edit</button>
               <button class="btn btn-default" type="button" id="profileImport">Import File</button>
               <button class="btn btn-default" type="button" id="profileExport">Export File</button>
-			  <br><br><br>
-			  <textarea id="profileText" placeholder="Paste your profile information here to import it as text. Press 'Export Text' to get your currently saved profiles." ></textarea><br>
-			  <button class="btn btn-default" type="button" id="profileImportText">Import Text</button>
-              <button class="btn btn-default" type="button" id="profileExportText">Export Text</button>			  
+              <br><br><br>
+              <textarea id="profileText" placeholder="Paste your profile information here to import it as text. Press 'Export Text' to get your currently saved profiles." ></textarea><br>
+              <button class="btn btn-default" type="button" id="profileImportText">Import Text</button>
+              <button class="btn btn-default" type="button" id="profileExportText">Export Text</button>
             </form>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -2517,8 +2517,12 @@
               <div class="form-group"><select class="form-control" id="profiles"></select></div>
               <button class="btn btn-default" type="button" id="profileAdd">Add</button>
               <button class="btn btn-default" type="button" id="profileEdit">Edit</button>
-              <button class="btn btn-default" type="button" id="profileImport">Import</button>
-              <button class="btn btn-default" type="button" id="profileExport">Export</button>
+              <button class="btn btn-default" type="button" id="profileImport">Import File</button>
+              <button class="btn btn-default" type="button" id="profileExport">Export File</button>
+			  <br><br><br>
+			  <textarea id="profileText" placeholder="Paste your profile information here to import it as text. Press 'Export Text' to get your currently saved profiles." ></textarea><br>
+			  <button class="btn btn-default" type="button" id="profileImportText">Import Text</button>
+              <button class="btn btn-default" type="button" id="profileExportText">Export Text</button>			  
             </form>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -2506,24 +2506,39 @@
 
         <!-- Theme Selection -->
         <div class="row">
-          <div class="col col-md-8"><h4>The theme selection changes the look and feel of this site.</h4></div>
-          <div class="col col-md-4"><select class="form-control" id="themes"><!-- Gets filled by jQuery. --></select></div>
+          <div class="col col-xs-12 col-sm-4 col-md-6"><h4>Theme selection:</h4></div>
+          <div class="col col-xs-12 col-sm-8 col-md-6"><select class="form-control" id="themes"><!-- Gets filled by jQuery. --></select></div>
         </div>
         <!-- Profile Selection -->
         <div class="row">
-          <div class="col col-md-6"><h4>Switch your profiles at will</h4></div>
-          <div class="col col-md-6">
-            <form class="form-inline  pull-right">
-              <div class="form-group"><select class="form-control" id="profiles"></select></div>
-              <button class="btn btn-default" type="button" id="profileAdd">Add</button>
-              <button class="btn btn-default" type="button" id="profileEdit">Edit</button>
-              <button class="btn btn-default" type="button" id="profileImport">Import File</button>
-              <button class="btn btn-default" type="button" id="profileExport">Export File</button>
-              <br><br><br>
-              <textarea id="profileText" placeholder="Paste your profile information here to import it as text. Press 'Export Text' to get your currently saved profiles." ></textarea><br>
-              <button class="btn btn-default" type="button" id="profileImportText">Import Text</button>
-              <button class="btn btn-default" type="button" id="profileExportText">Export Text</button>
+          <div class="col col-xs-12 col-sm-4 col-md-6"><h4>Profile management:</h4></div>
+          <div class="col col-xs-12 col-sm-8 col-md-6">
+            <form class="form-inline input-group pull-right">
+              <select class="form-control" id="profiles"></select>
+              <span class="input-group-btn">
+                <button class="btn btn-default" type="button" id="profileAdd">Add</button>
+                <button class="btn btn-default" type="button" id="profileEdit">Edit</button>
+              </span>
             </form>
+          </div>
+        </div>
+        <!-- Import/Export -->
+        <div class="row">
+          <div class="col-xs-12 col-sm-4 col-md-6"><h4>Data import/export:</h4></div>
+          <div class="col-xs-12 col-sm-8 col-md-6">
+            <form class="form-inline">
+              <span class="btn-group pull-left">
+                <button class="btn btn-default" type="button" id="profileImport">Import File</button>
+                <button class="btn btn-default" type="button" id="profileExport">Export File</button>
+              </span>
+              <span class="btn-group pull-right">
+                <button class="btn btn-default" type="button" id="profileImportText">Import Text</button>
+                <button class="btn btn-default" type="button" id="profileExportText">Export Text</button>
+              </span>
+            </form>
+          </div>
+          <div class="col col-xs-12">
+            <textarea id="profileText" class="form-control" placeholder="Paste your profile information here to import it as text. Press 'Export Text' to get your currently saved profiles." ></textarea>
           </div>
         </div>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -177,6 +177,31 @@ var profilesKey = 'darksouls3_profiles';
           fr.readAsText(fileInput.files[0]);
           fr.onload = dataLoadCallback;
         });
+		
+		/*
+        *  Import & Export using textarea instead of files
+        */
+        $('#profileExportText').click(function(){
+          var text = JSON.stringify(profiles);
+		  document.getElementById("profileText").value=text; 
+        });
+
+        $('#profileImportText').click(function(){
+			if (!confirm('Are you sure you want to import profile data?')) {
+				return;
+			}
+			try {
+				var jsonProfileData = JSON.parse(document.getElementById("profileText").value);
+				profiles = jsonProfileData;
+				$.jStorage.set(profilesKey, profiles);
+				populateProfiles();
+				populateChecklists();
+				$('#profiles').trigger("change");
+				location.reload();
+			} catch(e) {
+				alert(e); // error in the above string (in this case, yes)!
+			}
+        });
 
         $("#toggleHideCompleted").change(function() {
             var hidden = !$(this).is(':checked');
@@ -258,6 +283,9 @@ var profilesKey = 'darksouls3_profiles';
                 $el.click();
             }
         });
+		
+		// Refresh the import/export textbox
+		document.getElementById("profileText").value=""; 
     }
 
     // Setup ("bootstrap", haha) styling

--- a/js/main.js
+++ b/js/main.js
@@ -283,9 +283,6 @@ var profilesKey = 'darksouls3_profiles';
                 $el.click();
             }
         });
-
-        // Refresh the import/export textbox
-        document.getElementById("profileText").value=""; 
     }
 
     // Setup ("bootstrap", haha) styling
@@ -388,6 +385,8 @@ var profilesKey = 'darksouls3_profiles';
                 this.innerHTML = overallChecked + '/' + overallCount;
                 $(this).removeClass('done').addClass('in_progress');
             }
+        // Update textarea for profile export
+        document.getElementById("profileText").value = JSON.stringify(profiles);
         });
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -182,8 +182,9 @@ var profilesKey = 'darksouls3_profiles';
         *  Import & Export using textarea instead of files
         */
         $('#profileExportText').click(function(){
-            var text = JSON.stringify(profiles);
-            document.getElementById("profileText").value=text; 
+            document.getElementById("profileText").value = JSON.stringify(profiles);
+            document.getElementById("profileText").select();
+            document.execCommand("copy");
         });
 
         $('#profileImportText').click(function(){

--- a/js/main.js
+++ b/js/main.js
@@ -177,30 +177,30 @@ var profilesKey = 'darksouls3_profiles';
           fr.readAsText(fileInput.files[0]);
           fr.onload = dataLoadCallback;
         });
-		
-		/*
+
+        /*
         *  Import & Export using textarea instead of files
         */
         $('#profileExportText').click(function(){
-          var text = JSON.stringify(profiles);
-		  document.getElementById("profileText").value=text; 
+            var text = JSON.stringify(profiles);
+            document.getElementById("profileText").value=text; 
         });
 
         $('#profileImportText').click(function(){
-			if (!confirm('Are you sure you want to import profile data?')) {
-				return;
-			}
-			try {
-				var jsonProfileData = JSON.parse(document.getElementById("profileText").value);
-				profiles = jsonProfileData;
-				$.jStorage.set(profilesKey, profiles);
-				populateProfiles();
-				populateChecklists();
-				$('#profiles').trigger("change");
-				location.reload();
-			} catch(e) {
-				alert(e); // error in the above string (in this case, yes)!
-			}
+            if (!confirm('Are you sure you want to import profile data?')) {
+                return;
+            }
+            try {
+                var jsonProfileData = JSON.parse(document.getElementById("profileText").value);
+                profiles = jsonProfileData;
+                $.jStorage.set(profilesKey, profiles);
+                populateProfiles();
+                populateChecklists();
+                $('#profiles').trigger("change");
+                location.reload();
+            } catch(e) {
+                alert(e); // error in the above string (in this case, yes)!
+            }
         });
 
         $("#toggleHideCompleted").change(function() {
@@ -283,9 +283,9 @@ var profilesKey = 'darksouls3_profiles';
                 $el.click();
             }
         });
-		
-		// Refresh the import/export textbox
-		document.getElementById("profileText").value=""; 
+
+        // Refresh the import/export textbox
+        document.getElementById("profileText").value=""; 
     }
 
     // Setup ("bootstrap", haha) styling

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-02-15 22:44
+#version 2018-02-22 1:11
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-02-22 1:11
+#version 2018-02-22 2:00
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-02-22 2:00
+#version 2018-02-22 2:22
 
 index.html
 


### PR DESCRIPTION
All file downloads are blocked in the Steam overlay browser (and the upload browser is iffy as well), so currently you can't export your profiles. I added a textfield that one can use to export and import the profiles and then save them with notepad etc.

I set it to clear the textfield on page load for now, but I think the best would be if it always reflected the current status of the profile data so the "export text" button could be removed completely. Just wasn't really sure where to put that, JS isn't my strongest language by any stretch.