### PR TITLE
Fading "Hide Completed" button

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -78,6 +78,9 @@ h3 {
 .fadingbutton.back-to-top {
   right: 0;
 }
+.fadingbutton.togglehide {
+  left: 0;
+}
 
 .btn-collapse {
   padding: 4px 10px 1px;
@@ -126,13 +129,18 @@ input[type="checkbox"]:checked + .item_content {
   text-decoration: line-through;
 }
 
-input[type="checkbox"] ~ .glyphicon-eye-close { display:none; }
-
-input[type="checkbox"]:checked ~ .glyphicon-eye-close { display: inline-block; }
-
-input[type="checkbox"] ~ .glyphicon-eye-open { display: inline-block; }
-
-input[type="checkbox"]:checked ~ .glyphicon-eye-open { display: none; }
+input[type="checkbox"] ~ .glyphicon-eye-close,
+input[type="checkbox"] ~ * > .glyphicon-eye-close,
+input[type="checkbox"]:checked ~ .glyphicon-eye-open,
+input[type="checkbox"]:checked ~ * > .glyphicon-eye-open {
+  display: none;
+}
+input[type="checkbox"] ~ .glyphicon-eye-open,
+input[type="checkbox"] ~ * > .glyphicon-eye-open,
+input[type="checkbox"]:checked ~ .glyphicon-eye-close,
+input[type="checkbox"]:checked ~ * > .glyphicon-eye-close {
+  display: inline-block;
+}
 
 textarea#profileText {
   height: 15em;

--- a/css/main.css
+++ b/css/main.css
@@ -57,25 +57,26 @@ h3 {
  overflow: hidden;
 }
 
-.back-to-top {
-	position: fixed;
-	bottom: 2em;
-	right: 0px;
-	text-decoration: none;
-	color: #000000;
-	background-color: rgba(235, 235, 235, 0.80);
-	font-size: 12px;
-	padding: 1em;
-	display: none;
-	/* The "Paper" bootstrap theme modifies the transition properties;
-	reset them to the default value to prevent ruining the fadeIn() */
-	-webkit-transition: all 0s ease 0s;
-	-o-transition: all 0s ease 0s;
-	transition: all 0s ease 0s;
+.fadingbutton {
+  position: fixed;
+  bottom: 2em;
+  text-decoration: none;
+  color: #000000;
+  background-color: rgba(235, 235, 235, 0.80);
+  font-size: 12px;
+  padding: 1em;
+  display: none;
+  /* The "Paper" bootstrap theme modifies the transition properties;
+  reset them to the default value to prevent ruining the fadeIn() */
+  -webkit-transition: all 0s ease 0s;
+  -o-transition: all 0s ease 0s;
+  transition: all 0s ease 0s;
 }
-
-.back-to-top:hover{
-	background-color: rgba(135, 135, 135, 0.50);
+.fadingbutton:hover {
+  background-color: rgba(135, 135, 135, 0.50);
+}
+.fadingbutton.back-to-top {
+  right: 0;
 }
 
 .btn-collapse {

--- a/index.html
+++ b/index.html
@@ -32,11 +32,11 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse" id="nav-collapse">
         <ul class="nav navbar-nav">
-          <li class="active"><a href="#tabPlaythrough" data-toggle="tab">Playthrough</a></li>
-          <li><a href="#tabChecklists" data-toggle="tab">Achievements</a></li>
-          <li><a href="#tabWeaponsShields" data-toggle="tab">Weapons/Shields</a></li>
-          <li><a href="#tabArmors" data-toggle="tab">Armor</a></li>
-          <li><a href="#tabMisc" data-toggle="tab">Misc</a></li>
+          <li class="active"><a href="#tabPlaythrough" data-toggle="tab" data-target="#tabPlaythrough,#btnHideCompleted">Playthrough</a></li>
+          <li><a href="#tabChecklists" data-toggle="tab" data-target="#tabChecklists,#btnHideCompleted">Achievements</a></li>
+          <li><a href="#tabWeaponsShields" data-toggle="tab" data-target="#tabWeaponsShields,#btnHideCompleted">Weapons/Shields</a></li>
+          <li><a href="#tabArmors" data-toggle="tab" data-target="#tabArmors,#btnHideCompleted">Armor</a></li>
+          <li><a href="#tabMisc" data-toggle="tab" data-target="#tabMisc,#btnHideCompleted">Misc</a></li>
           <li><a href="#tabFAQ" data-toggle="tab"><span class="glyphicon glyphicon-question-sign"></span> FAQ</a></li>
           <li><a href="#tabOptions" data-toggle="tab"><span class="glyphicon glyphicon-cog"></span></a></li>
         </ul>
@@ -57,7 +57,7 @@
 
     <div class="tab-content">
       <!-- Hide Completed Toggle -->
-      <div class="btn-group" role="group">
+      <div class="tab-pane active in" id="btnHideCompleted">
         <div class="btn-group" role="group" data-toggle="buttons">
           <label class="btn btn-default">
               <input type="checkbox" id="toggleHideCompleted" />

--- a/index.html
+++ b/index.html
@@ -60,10 +60,15 @@
       <div class="tab-pane active in" id="btnHideCompleted">
         <div class="btn-group" role="group" data-toggle="buttons">
           <label class="btn btn-default">
-              <input type="checkbox" id="toggleHideCompleted" />
+            <input type="checkbox" id="toggleHideCompleted">
+            <span class="glyphicon glyphicon-eye-close"></span>
+            <span class="glyphicon glyphicon-eye-open"></span>
+            Hide Completed
+            <a class="fadingbutton togglehide">
               <span class="glyphicon glyphicon-eye-close"></span>
               <span class="glyphicon glyphicon-eye-open"></span>
               Hide Completed
+            </a>
           </label>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -2581,7 +2581,7 @@
     <input name="upload" type="file" id="fileInput" />
   </div>
 
-  <a href="#" class="back-to-top">Back to Top</a>
+  <a href="#" class="fadingbutton back-to-top">Back to Top</a>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/andris9/jStorage/v0.4.12/jstorage.min.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -508,9 +508,9 @@ var profilesKey = 'darksouls3_profiles';
         var duration = 500;
         $(window).scroll(function() {
             if ($(this).scrollTop() > offset) {
-                $('.back-to-top').fadeIn(duration);
+                $('.fadingbutton').fadeIn(duration);
             } else {
-                $('.back-to-top').fadeOut(duration);
+                $('.fadingbutton').fadeOut(duration);
             }
         });
 

--- a/js/main.js
+++ b/js/main.js
@@ -205,12 +205,24 @@ var profilesKey = 'darksouls3_profiles';
         });
 
         $("#toggleHideCompleted").change(function() {
+            // Store information about the old scroll position
+            var oldPos = $(window).scrollTop();
+            var labels = $('ul>li>div>label:visible:not(.completed)');
+            var oldOff = labels.map(function(){return $(this).offset().top});
+
             var hidden = !$(this).is(':checked');
 
             $('body').toggleClass('hide_completed', !hidden);
 
             profiles[profilesKey][profiles.current].hide_completed = !hidden;
             $.jStorage.set(profilesKey, profiles);
+            
+            // Try to find a reasonable new scroll position
+            for (var a=0; a<oldOff.length-1; a++) if (oldOff[a]>oldPos) break;
+            for (var b=0; b<oldOff.length-1; b++) if (oldOff[b]>oldPos+$(window).height()) break;
+            if (!oldOff.length || $('h2:visible').last().offset().top>oldPos) $('html, body').scrollTop(oldPos);
+            else if (a==b) $('html, body').scrollTop(Math.round(labels.eq(b).offset().top)-Math.round($(window).height()/2));
+            else {var c = Math.round((a+b)/2); $('html, body').scrollTop(oldPos+Math.round(labels.eq(c).offset().top)-Math.round(oldOff[c]));}
         });
 
         $('[data-item-toggle]').change(function() {

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-03-08 20:45
+#version 2018-03-08 20:52
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-03-08 20:37
+#version 2018-03-08 20:45
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-03-08 20:52
+#version 2018-03-08 23:09
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-02-26 13:53
+#version 2018-03-08 20:37
 
 index.html
 


### PR DESCRIPTION
OK, so here's a new feature... but first, a story:
I usually use the sheet with "Hide Completed" activated, so that entries just disappear as I check them off. However, I accidentaly misclicked and checked of the wrong item. Since that entry is now hidden, that mistake is a bit tedious to undo: Scroll all the way up; disable hide; scroll down and locate the right position; uncheck the accidentally checked entry; scroll up; re-enable hide; scroll down and locate the right position again to carry on. So I thought: Wouldn't it be better if I could just toggle the hide completed state right in place, without having to scroll up all the way.

Therefore, this PR adds the "Hide Completed" button directly opposite of the existing "Back to Top" button, and using the same fade-in and fade-out mechanics. As toggling hide completed can cause hundreds of elements to (dis-)appear on the page, it should be expected that not all browser will handle this in the same manner. As it turns out, some browsers (like Firefox) do really not behave in a useful way, so that clicking the button might land you much farther up or down the sheet than where you were located before. Thus, I had to come up with some javascript logic to try and deduce a good scroll position to display after toggling the hide completed state. Clearly there can be no perfect solution to this exercise, but I tried to come up with something reasonable. Here are the rules I currently apply when clicking the hide completed button:
- If there are no eligible unchecked ckeckboxes on the page (this is an edge case that should only occur if either all categories on the page are collapsed or if each and every checkbox on the page is already checked), then the scroll offset will simply stay the same.
- If the current scroll position is quite close to the top of the page (to be exact, if the title of the current tab is still visible), the scroll offset will also stay the same.
- If your current view consists only of checked checkboxes, then the scroll position after hiding them will be changed so that whatever unchecked boxes were surrounding this bulk of checked boxes are now moved to near the center of the screen.
- And of course the most important case: If your current window displays at least one unchecked box, then the new scroll offset will be calculated such that at least one unchecked box (ideally one that is currently near the middle of the screen) should appear in exactly the same visible position before and after toggling hide completed.

Let me know whether you can think of a better algorithm, or if you find any situation where the current algorithm breaks down.