### PR TITLE
Assorted improvements 9

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -112,6 +112,7 @@ var profilesKey = 'darksouls3_profiles';
                 $.jStorage.set(profilesKey, profiles);
                 populateProfiles();
                 populateChecklists();
+                restoreState(profiles.current);
             }
             //_gaq.push(['_trackEvent', 'Profile', 'Create', profile]);
         });
@@ -143,6 +144,7 @@ var profilesKey = 'darksouls3_profiles';
             $.jStorage.set(profilesKey, profiles);
             populateProfiles();
             populateChecklists();
+            restoreState(profiles.current);
             $('#profileModal').modal('hide');
             //_gaq.push(['_trackEvent', 'Profile', 'Delete']);
         });

--- a/js/main.js
+++ b/js/main.js
@@ -269,9 +269,6 @@ var profilesKey = 'darksouls3_profiles';
         if (!(profile_name in profiles[profilesKey])) profiles[profilesKey][profile_name] = {};
         if (!('checklistData' in profiles[profilesKey][profile_name]))
             profiles[profilesKey][profile_name].checklistData = {};
-
-        if (!('state' in profiles[profilesKey][profile_name]))
-            profiles[profilesKey][profile_name].state = {};
         if (!('collapsed' in profiles[profilesKey][profile_name]))
             profiles[profilesKey][profile_name].collapsed = {};
         if (!('current_tab' in profiles[profilesKey][profile_name]))

--- a/js/main.js
+++ b/js/main.js
@@ -302,14 +302,14 @@ var profilesKey = 'darksouls3_profiles';
     /// restore all saved state, except for the current tab
     /// used on page load or when switching profiles
     function restoreState(profile_name) {
-        $.each(profiles[profilesKey][profile_name].collapsed, function(key, value) {
-            var $el = $('a[href="' + key + '"]');
-            var active = $el.hasClass('collapsed');
+        $('a[href$="_col"]').each(function() {
+            var value = profiles[profilesKey][profile_name].collapsed[$(this).attr('href')];
+            var active = $(this).hasClass('collapsed');
 
             // interesting note: this condition is the same as (value ^ active),
             // but there's no logical xor in JS as far as I know; also, this is more readable
             if ((value && !active) || (!value && active)) {
-                $el.click();
+                $($(this).attr('href')).collapse('toggle');
             }
         });
 

--- a/js/main.js
+++ b/js/main.js
@@ -47,7 +47,6 @@ var profilesKey = 'darksouls3_profiles';
         $('.checkbox input[type="checkbox"]').click(function() {
             var id = $(this).attr('id');
             var isChecked = profiles[profilesKey][profiles.current].checklistData[id] = $(this).prop('checked');
-            //_gaq.push(['_trackEvent', 'Checkbox', (isChecked ? 'Check' : 'Uncheck'), id]);
             if (isChecked === true) {
               $('[data-id="'+id+'"] label').addClass('completed');
             } else {
@@ -75,7 +74,6 @@ var profilesKey = 'darksouls3_profiles';
             restoreState(profiles.current);
 
             calculateTotals();
-            //_gaq.push(['_trackEvent', 'Profile', 'Change', profiles.current]);
         });
 
         $('#profileAdd').click(function() {
@@ -85,7 +83,6 @@ var profilesKey = 'darksouls3_profiles';
             $('#profileModalUpdate').hide();
             $('#profileModalDelete').hide();
             $('#profileModal').modal('show');
-            //_gaq.push(['_trackEvent', 'Profile', 'Add']);
         });
 
         $('#profileEdit').click(function() {
@@ -99,7 +96,6 @@ var profilesKey = 'darksouls3_profiles';
                 $('#profileModalDelete').hide();
             }
             $('#profileModal').modal('show');
-            //_gaq.push(['_trackEvent', 'Profile', 'Edit', profiles.current]);
         });
 
         $('#profileModalAdd').click(function(event) {
@@ -114,7 +110,6 @@ var profilesKey = 'darksouls3_profiles';
                 populateChecklists();
                 restoreState(profiles.current);
             }
-            //_gaq.push(['_trackEvent', 'Profile', 'Create', profile]);
         });
 
         $('#profileModalUpdate').click(function(event) {
@@ -128,7 +123,6 @@ var profilesKey = 'darksouls3_profiles';
                 populateProfiles();
             }
             $('#profileModal').modal('hide');
-            //_gaq.push(['_trackEvent', 'Profile', 'Update', profile]);
         });
 
         $('#profileModalDelete').click(function(event) {
@@ -146,7 +140,6 @@ var profilesKey = 'darksouls3_profiles';
             populateChecklists();
             restoreState(profiles.current);
             $('#profileModal').modal('hide');
-            //_gaq.push(['_trackEvent', 'Profile', 'Delete']);
         });
 
         $('#profileExport').click(function(){

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-04-28 13:01
+#version 2018-04-28 13:49
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-04-21 23:41
+#version 2018-04-28 1:30
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-04-28 13:49
+#version 2018-04-28 14:02
 
 index.html
 

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-#version 2018-04-28 1:30
+#version 2018-04-28 13:01
 
 index.html
 


### PR DESCRIPTION
- **fix two bugs in restoreState():** First, a description of the bugs:
  - Start with a clean slate; create two profiles, let's call them "coll" and "open"
  - On "open", do not touch any category (they should all be open by default)
  - Switch to "coll"; collapse a test category; switch to "open"
  - **Bug1:** test category got collapsed
  - Open up the category again; switch to "coll"; switch to "open"; switch to "coll"
  - **Bug2:** test category is now open here [**Bug2 bonus:** switch to "open"; switch to "coll"; test category will be collapsed again; repeat and alternate forever...]

  The cause of bug1 is that the iteration only runs over categories that have an entry in the `collapsed` object of the profile that is being switched to (and such attributes are only added when a category is collapsed for the first time). Therefore, it can never re-open an untouched category in "open" that has been collapsed in "coll". This bug is fixed by iterating over all collapsibles instead.
  The cause of bug2 is that it tries to restore the state by clicking on the button. This is terrible, since doing so invokes the click handler, which actually changes the saved state in the profile as well. Therefore, each time the profile is switched to, both the state of the page and the state of the profile are changed, and they can never get in sync again, leading to the alternating behavior. The only reason why the collapsed state of a single profile can be kept intact at all after a simple page refresh is that, on reload, `restoreState()` runs before the click handler is even attached. Anyway, this bug is fixed by toggling the collapse directly.

- **call restoreState() in #profileModalAdd and #profileModalDelete:** In addition to restoring the collapsed state as above, this also restores the filtered classes and fixes #133.

- **remove unused 'state' object:** An empty object named `state` was inserted into each newly created profile, although it has never been used.

- **remove dead comments:** These referred to the old version of Google Analytics, `ga.js`, and have never been used.

[Question1: What's you plan regarding the current version of Google Analytics, `analytics.js`, which is being loaded in the sheet? (Are you even using the pageview data it collects, and if yes, what did you learn?) If you don't have any good plan going forward, analytics should be removed now.]

[Question2: What's the deal with issue #135? I have not been able to reproduce it. Can you still reproduce it, and if yes, how? (And using which browsers?) If not, I think that issue should be closed.]