### PR TITLE
jStorage url is down

### DIFF
--- a/index.html
+++ b/index.html
@@ -2820,7 +2820,7 @@
   <a class="btn btn-default btn-sm fadingbutton back-to-top">Back to Top&thinsp;<span class="glyphicon glyphicon-arrow-up"></span></a>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
-  <script src="https://cdn.rawgit.com/andris9/jStorage/v0.4.12/jstorage.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jStorage/0.4.12/jstorage.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jets/0.8.0/jets.min.js"></script>
   <script src="js/jquery.highlight.js"></script>


### PR DESCRIPTION
Change jStorage URL to cdnjs to fix broken link.

The current one is down and is causing the page to not load the checkboxes/buttons/counts.

<img width="731" height="458" alt="image" src="https://github.com/user-attachments/assets/f80725cf-62fd-48c9-8f15-13a79f943e7d" />



